### PR TITLE
Gauss quadrature

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 2.3.0 ()
+    - fix Gauss-Legendre quadrature weights
 
 2.2.1 (22. August 2016)
     - fix delayoffset for FIR fractional delay filter

--- a/SFS_general/get_spherical_grid.m
+++ b/SFS_general/get_spherical_grid.m
@@ -18,7 +18,7 @@ function [points,weights] = get_spherical_grid(number,conf)
 %   desired file is not available on the hard disk, the function tries to
 %   download it directly from github.
 %   For conf.secondary_sources.grid='gauss' the grid positions are calculated
-%   after Ahrens (2012), p. 121 (see also: Rafaely (2015))
+%   after Ahrens (2012), p. 121 (see also: Rafaely (2015), p. 64)
 %
 %   References:
 %       J. Ahrens (2012) - "Analytic Methods of Sound Field Synthesis", Springer.

--- a/SFS_general/get_spherical_grid.m
+++ b/SFS_general/get_spherical_grid.m
@@ -126,8 +126,8 @@ elseif strcmp('gauss',spherical_grid)
     r = ones(size(phi));
     % Convert to cartesian
     [points(:,1) points(:,2) points(:,3)] = sph2cart(phi(:),theta(:),r(:));
-    % Incorporating integration weights
-    weights = weights(:).*cos(theta(:));
+    % Normalize integration weights
+    weights = weights(:)*pi/number;
 else
     error(['%s: the given spherical grid is not available, have a look at ' ...
         'http://github.com/sfstoolbox/data for avialable grids.'], ...

--- a/SFS_general/get_spherical_grid.m
+++ b/SFS_general/get_spherical_grid.m
@@ -18,10 +18,11 @@ function [points,weights] = get_spherical_grid(number,conf)
 %   desired file is not available on the hard disk, the function tries to
 %   download it directly from github.
 %   For conf.secondary_sources.grid='gauss' the grid positions are calculated
-%   after Ahrens (2012), p. 121
+%   after Ahrens (2012), p. 121 (see also: Rafaely (2015))
 %
 %   References:
 %       J. Ahrens (2012) - "Analytic Methods of Sound Field Synthesis", Springer.
+%       B. Rafaely (2015) - "Fundamentals of Spherical Array Processing", Springer.
 %
 %   See also: secondary_source_positions,
 %       weights_for_points_on_a_sphere_rectangle


### PR DESCRIPTION
This should fix the quadrature weights for Gauss-Legendre spherical sampling.
Below, you see how the old weights fail to ensure orthonormality.
![gauss_old](https://cloud.githubusercontent.com/assets/16763319/19246513/030fcb2e-8f27-11e6-967d-8eb115429e7a.png)

```Matlab
Nmax = 5;
conf = SFS_config;
conf.secondary_sources.grid = 'gauss';
[grid,weights] = get_spherical_grid(2*(Nmax+1)^2,conf);
[phi,theta] = cart2sph(grid(:,1),grid(:,2),grid(:,3));

Ynm = [];
for n = 0:Nmax
    for m = -n:n
        Ynm  = [Ynm sphharmonics(n,m,theta,phi)];
    end
end
inner_products = Ynm'*diag(weights)*Ynm;

figure
imagesc([0,(Nmax+1)^2],[0,(Nmax+1)^2],abs(inner_products));
xlabel('n^2 + n + m');
ylabel('n^2 + n + m');
```