### PR TITLE
Correct amplitude wfs time domain

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 2.3.0 ()
     - fix Gauss-Legendre quadrature weights
+    - fix default 2.5D WFS driving function in time domain
+    - correct absolute amplitude values of WFS in time domain
 
 2.2.1 (22. August 2016)
     - fix delayoffset for FIR fractional delay filter

--- a/SFS_ir/dummy_irs.m
+++ b/SFS_ir/dummy_irs.m
@@ -62,13 +62,14 @@ isargstruct(conf);
 %% ===== Configuration ===================================================
 fs = conf.fs;
 c = conf.c;
-dirac_position = 300;
+distance = 1;
+dirac_position = round(distance/c*fs);
 
 
 %% ===== Computation =====================================================
 ir = zeros(1,2,nsamples);
 % Create dirac pulse
-ir(:,:,dirac_position) = 1;
+ir(:,:,dirac_position) = 1/(4*pi);
 % Store data
 sofa = SOFAgetConventions('SimpleFreeFieldHRIR');
 sofa.Data.IR = ir;
@@ -83,6 +84,5 @@ sofa.ListenerView = [1 0 0];
 sofa.ListenerUp = [0 0 1];
 elevation = 0;
 azimuth = 0;
-distance = dirac_position/fs*c;
 sofa.SourcePosition = [nav2sph(azimuth) elevation distance];
 sofa = SOFAupdateDimensions(sofa);

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
@@ -148,7 +148,7 @@ elseif strcmp('2.5D',dimension)
          %
          % Delay and amplitude weight
          delay = 1./c .* r;
-         weight = g0 ./ sqrt(2.*pi) .* vector_product(x0-xs,nx0,2) ./ r.^2;
+         weight = g0 ./ sqrt(2.*pi) .* vector_product(x0-xs,nx0,2) ./ r.^(3/2);
          %
      case 'reference_line'
          % Driving function with two stationary phase approximations,

--- a/SFS_time_domain/wfs_fir_prefilter.m
+++ b/SFS_time_domain/wfs_fir_prefilter.m
@@ -55,7 +55,8 @@ isargstruct(conf);
 
 %% ===== Configuration ==================================================
 fs = conf.fs;                  % Sampling rate
-dimension = conf.dimension;    % dimensionality
+c = conf.c;                    % Speed of sound
+dimension = conf.dimension;    % Dimensionality
 flow = conf.wfs.hpreflow;      % Lower frequency limit of preequalization
                                % filter (= frequency when subwoofer is active)
 fhigh = conf.wfs.hprefhigh;    % Upper frequency limit of preequalization
@@ -92,19 +93,21 @@ if strcmp('2.5D',dimension)
     %
     %  See http://sfstoolbox.org/#equation-h.wfs.2.5D
     %
-    H(idxflow:idxfhigh) = sqrt(f(idxflow:idxfhigh)./fhigh);
+    H(idxflow:idxfhigh) = sqrt(2*pi*f(idxflow:idxfhigh)/c);
+    H(idxfhigh:end) = H(idxfhigh);
 elseif strcmp('3D',dimension) || strcmp('2D',dimension)
     %
     %  H(f) = f/fhigh, for flow<=f<=fhigh
     %
     %  See http://sfstoolbox.org/#equation-h.wfs
     %
-    H(idxflow:idxfhigh) = f(idxflow:idxfhigh)./fhigh;
+    H(idxflow:idxfhigh) = 2*pi*f(idxflow:idxfhigh)/c;
+    H(idxfhigh:end) = H(idxfhigh);
 else
     error('%s: %s is not a valid conf.dimension entry',upper(mfilename),dimension);
 end
 % Set the response for idxf < idxflow to the value at idxflow
-H(1:idxflow) = H(idxflow)*ones(1,idxflow);
+H(1:idxflow) = H(idxflow);
 
 % Compute filter
 hpre = firls(Nfilt,2*f/fs,H);


### PR DESCRIPTION
I suggest the following changes to achieve a correct amplitude of a point source in WFS when in the time domain:

1. Correction of a mistake in the default 2.5D WFS driving function `driving_function_imp_wfs_ps()`.

2. Adding the missing amplitude terms to the FIR prefilter in `wfs_fir_prefilter()`, both for 2.5D and 3D.

3. Change amplitude and delay of `dummy_irs()` to 1/(4*pi) in 1 m distance.

These changes can be found in the three commits.
What do you think of this? Do these changes conflict with some things I missed?