### PR TITLE
Correct Green's function amplitude

### DIFF
--- a/SFS_analysis/time_response_point_source.m
+++ b/SFS_analysis/time_response_point_source.m
@@ -1,0 +1,98 @@
+function varargout = time_response_point_source(X,xs,conf)
+%TIME_RESPONSE_POINT_SOURCE simulates the time response for a point source at
+%the given listener position
+%
+%   Usage: [s,t] = time_response_point_source(X,xs,conf)
+%
+%   Input parameters:
+%       X           - listener position / m
+%       xs          - position of point source / m
+%       conf        - configuration struct (see SFS_config)
+%
+%   Output parameters:
+%       s           - simulated time response
+%       t           - corresponding time axis / s
+%
+%   TIME_RESPONSE_POINT_SOURCE(X,xs,conf) simulates the time response of the
+%   sound field at the given position X. The sound field is simulated for a
+%   point source at the given source position xs.
+%
+%   See also: sound_field_imp_wfs, freq_response_wfs, time_response_nfchoa
+
+%*****************************************************************************
+% The MIT License (MIT)                                                      *
+%                                                                            *
+% Copyright (c) 2010-2016 SFS Toolbox Developers                             *
+%                                                                            *
+% Permission is hereby granted,  free of charge,  to any person  obtaining a *
+% copy of this software and associated documentation files (the "Software"), *
+% to deal in the Software without  restriction, including without limitation *
+% the rights  to use, copy, modify, merge,  publish, distribute, sublicense, *
+% and/or  sell copies of  the Software,  and to permit  persons to whom  the *
+% Software is furnished to do so, subject to the following conditions:       *
+%                                                                            *
+% The above copyright notice and this permission notice shall be included in *
+% all copies or substantial portions of the Software.                        *
+%                                                                            *
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+% IMPLIED, INCLUDING BUT  NOT LIMITED TO THE  WARRANTIES OF MERCHANTABILITY, *
+% FITNESS  FOR A PARTICULAR  PURPOSE AND  NONINFRINGEMENT. IN NO EVENT SHALL *
+% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+% LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT, TORT  OR OTHERWISE, ARISING *
+% FROM,  OUT OF  OR IN  CONNECTION  WITH THE  SOFTWARE OR  THE USE  OR OTHER *
+% DEALINGS IN THE SOFTWARE.                                                  *
+%                                                                            *
+% The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
+% methods like wave field synthesis or higher order ambisonics.              *
+%                                                                            *
+% http://sfstoolbox.org                                 sfstoolbox@gmail.com *
+%*****************************************************************************
+
+
+%% ===== Checking of input  parameters ==================================
+nargmin = 3;
+nargmax = 3;
+narginchk(nargmin,nargmax);
+isargposition(X);
+isargxs(xs);
+isargstruct(conf);
+
+
+%% ===== Configuration ==================================================
+% Plotting result
+useplot = conf.plot.useplot;
+fs = conf.fs;
+showprogress = conf.showprogress;
+% Disable progress bar for the sound field function
+conf.showprogress = 0;
+% Disable plotting, otherwise the sound_field_imp fails
+conf.plot.useplot = 0;
+
+
+%% ===== Computation ====================================================
+% Get the position of the loudspeaker from point source position.
+% NOTE: its directivity [0 -1 0] will be ignored
+x0 = [xs 0 -1 0 1];
+% Generate time axis (0-500 samples)
+t = (0:500)';
+s = zeros(1,length(t));
+for ii = 1:length(t)
+    if showprogress, progress_bar(ii,length(t)); end
+    % Calculate sound field at the listener position
+    p = sound_field_imp(X(1),X(2),X(3),x0,'ps',dirac_imp(),t(ii),conf);
+    s(ii) = real(p);
+end
+
+% Return parameter
+if nargout>0, varargout{1}=s; end
+if nargout>1, varargout{2}=t; end
+
+
+%% ===== Plotting ========================================================
+if nargout==0 || useplot
+    figure;
+    figsize(conf.plot.size(1),conf.plot.size(2),conf.plot.size_unit);
+    plot(t/fs*1000,s);
+    ylabel('amplitude / dB');
+    xlabel('time / ms');
+end

--- a/SFS_binaural_synthesis/ir_generic.m
+++ b/SFS_binaural_synthesis/ir_generic.m
@@ -85,7 +85,9 @@ for ii=1:size(x0,1)
     % If needed interpolate the given impulse response set and weight, delay the
     % impulse for the correct distance
     ir = get_ir(sofa,X,[phi 0],x0(ii,1:3),'cartesian',conf);
-
+    % Correct Green's function amplitude
+    ir = ir/(4*pi);
+    
     % === Sum up virtual loudspeakers/HRIRs and add loudspeaker time delay ===
     % Also applying the weights of the secondary sources including integration
     % weights or tapering windows etc.

--- a/SFS_binaural_synthesis/ir_point_source.m
+++ b/SFS_binaural_synthesis/ir_point_source.m
@@ -11,7 +11,7 @@ function ir = ir_point_source(X,phi,xs,sofa,conf)
 %       conf    - configuration struct (see SFS_config)
 %
 %   Output parameters:
-%       ir      - Impulse response (nx2 matrix)
+%       ir      - impulse response (nx2 matrix)
 %
 %   IR_POINT_SOURCE(X,phi,xs,sofa,conf) calculates a impulse response for a
 %   single loudspeaker at position xs and a listener located at X, looking

--- a/SFS_general/tapering_window.m
+++ b/SFS_general/tapering_window.m
@@ -1,5 +1,5 @@
 function win = tapering_window(x0,conf)
-%TAPERING_WINDOW generate a tapering window for a loudspeaker array
+%TAPERING_WINDOW generates a tapering window for a loudspeaker array
 %
 %   Usage: win = tapering_window(x0,conf)
 %
@@ -123,7 +123,7 @@ function [win] = part_hann_win(nls,tapwinlen)
     % splitted to both sides of the loudspeaker array.
     lenwin = round(tapwinlen*nls)+2;
     %
-    % Check if we have a to short window to apply it in a useful way. This can
+    % Check if we have a too short window to apply it in a useful way. This can
     % be the case for very short loudspeaker arrays (as used in Wierstorf2010).
     if lenwin<4
         win = ones(1,nls);

--- a/SFS_ir/dummy_irs.m
+++ b/SFS_ir/dummy_irs.m
@@ -69,7 +69,7 @@ dirac_position = round(distance/c*fs);
 %% ===== Computation =====================================================
 ir = zeros(1,2,nsamples);
 % Create dirac pulse
-ir(:,:,dirac_position) = 1/(4*pi);
+ir(:,:,dirac_position) = 1;
 % Store data
 sofa = SOFAgetConventions('SimpleFreeFieldHRIR');
 sofa.Data.IR = ir;

--- a/SFS_ir/get_ir.m
+++ b/SFS_ir/get_ir.m
@@ -133,6 +133,8 @@ if strcmp('SimpleFreeFieldHRIR',header.GLOBAL_SOFAConventions)
     % Find nearest neighbours and interpolate if desired and needed
     [neighbours,idx] = findnearestneighbour(x0(:,1:2)',xs(1:2),3);
     ir = sofa_get_data_fir(sofa,idx);
+    % Correct Green's function amplitude
+    ir = ir/(4*pi);
     ir = ir_correct_distance(ir,x0(idx,3),xs(3),conf);
     [ir,x0] = interpolate_ir(ir,neighbours,xs(1:2)',conf);
     [x0(1),x0(2),x0(3)] = sph2cart(x0(1),x0(2),xs(3));
@@ -185,6 +187,8 @@ elseif strcmp('MultiSpeakerBRIR',header.GLOBAL_SOFAConventions)
     end
     % Get the impulse responses, reshape and interpolate
     ir = sofa_get_data_fire(sofa,idx_head,idx_emitter);
+    % Correct Green's function amplitude
+    ir = ir/(4*pi);
     ir = reshape(ir,[size(ir,1) size(ir,2) size(ir,4)]); % [M R E N] => [M R N]
     ir = interpolate_ir(ir,neighbours_head,head_orientation',conf);
 

--- a/SFS_ir/get_ir.m
+++ b/SFS_ir/get_ir.m
@@ -133,8 +133,6 @@ if strcmp('SimpleFreeFieldHRIR',header.GLOBAL_SOFAConventions)
     % Find nearest neighbours and interpolate if desired and needed
     [neighbours,idx] = findnearestneighbour(x0(:,1:2)',xs(1:2),3);
     ir = sofa_get_data_fir(sofa,idx);
-    % Correct Green's function amplitude
-    ir = ir/(4*pi);
     ir = ir_correct_distance(ir,x0(idx,3),xs(3),conf);
     [ir,x0] = interpolate_ir(ir,neighbours,xs(1:2)',conf);
     [x0(1),x0(2),x0(3)] = sph2cart(x0(1),x0(2),xs(3));
@@ -187,8 +185,6 @@ elseif strcmp('MultiSpeakerBRIR',header.GLOBAL_SOFAConventions)
     end
     % Get the impulse responses, reshape and interpolate
     ir = sofa_get_data_fire(sofa,idx_head,idx_emitter);
-    % Correct Green's function amplitude
-    ir = ir/(4*pi);
     ir = reshape(ir,[size(ir,1) size(ir,2) size(ir,4)]); % [M R E N] => [M R N]
     ir = interpolate_ir(ir,neighbours_head,head_orientation',conf);
 

--- a/SFS_time_domain/sound_field_imp.m
+++ b/SFS_time_domain/sound_field_imp.m
@@ -133,8 +133,8 @@ d = d(end:-1:1,:);
 % Add additional zeros to the driving signal to ensure an amplitude of 0 in the
 % whole listening area before and after the real driving signal.
 % First get the maximum distance of the listening area and convert it into time
-% samples, than compare it to the size of the secondary sources. If the size is
-% biger use this for padding zeros.
+% samples, then compare it to the size of the secondary sources. If the size is
+% bigger use this for padding zeros.
 max_distance = norm( [max(xx(:)) max(yy(:)) max(zz(:))] - ...
     [min(xx(:)) min(yy(:)) min(zz(:))] );
 max_distance_in_samples = round(max(max_distance/c*fs,2*L/c*fs));
@@ -151,7 +151,7 @@ d = [d; zeros(max_distance_in_samples,size(d,2))];
 % Initialize empty sound field (dependent on the axes we want)
 p = zeros(size(x1));
 
-% Apply bandbass filter
+% Apply bandpass filter
 if usebandpass
     d = bandpass(d,bandpassflow,bandpassfhigh,conf);
 end
@@ -169,7 +169,7 @@ for ii = 1:size(x0,1)
 
     % Interpolate the driving function w.r.t. the propagation delay from
     % the secondary sources to a field point. The t returned from the Green's
-    % function already inlcudes the desired time shift of the driving signal.
+    % function already includes the desired time shift of the driving signal.
     % NOTE: the interpolation is required to account for the fractional
     % delay times from the loudspeakers to the field points
     ds = interp1(1:length(d(:,ii)),d(:,ii),t_delta,'spline');

--- a/SFS_time_domain/wfs_fir_prefilter.m
+++ b/SFS_time_domain/wfs_fir_prefilter.m
@@ -86,7 +86,7 @@ H = ones(1,length(f));
 %   |  flow
 %   -------------------------> f
 %
-% Pre-equilization filter from flow to fhigh
+% Pre-equalization filter from flow to fhigh
 if strcmp('2.5D',dimension)
     %           _______
     %  H(f) = \|f/fhigh, for flow<=f<=fhigh


### PR DESCRIPTION
This change corrects the amplitude of an SSR-BRS auralisation for the factor 1/(4*pi) of the Green's function. In order to work for calculation of WFS impulse responses in the time domain as well, this factor had to be removed from `dummy_irs()` (where it had been added in #112).