### PR TITLE
add secondary source selection and tapering for WFS auralisation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
     - fix Gauss-Legendre quadrature weights
     - fix default 2.5D WFS driving function in time domain
     - correct absolute amplitude values of WFS in time domain
+    - fix missing secondary source selection in ssr_brs_wfs()
 
 2.2.1 (22. August 2016)
     - fix delayoffset for FIR fractional delay filter

--- a/SFS_ssr/ssr_brs_wfs.m
+++ b/SFS_ssr/ssr_brs_wfs.m
@@ -67,6 +67,8 @@ isargstruct(conf);
 %% ===== Computation =====================================================
 % Secondary sources
 x0 = secondary_source_positions(conf);
+x0 = secondary_source_selection(x0,xs,src);
+x0 = secondary_source_tapering(x0,conf);
 % Calculate driving function
 d = driving_function_imp_wfs(x0,xs,src,conf);
 % Calculate brs set


### PR DESCRIPTION
Secondary source selection and tapering had been missing for WFS auralisation and are now added in `ssr_brs_wfs()`.