### PR TITLE
Correct WFS driving function time delay

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,10 @@
 2.3.0 ()
-    - fix Gauss-Legendre quadrature weights
-    - fix default 2.5D WFS driving function in time domain
+    - rename conf.wfs.t0 to conf.t0
+    - add delay_offset as return value to NFC-HOA time domain driving funtions
     - correct absolute amplitude values of WFS in time domain
+    - fix default 2.5D WFS driving function in time domain
+    - fix missing secondary source selection in ssr_brs_wfs()
+    - fix Gauss-Legendre quadrature weights
 
 2.2.1 (22. August 2016)
     - fix delayoffset for FIR fractional delay filter

--- a/SFS_analysis/time_response_wfs.m
+++ b/SFS_analysis/time_response_wfs.m
@@ -88,14 +88,15 @@ x0 = secondary_source_tapering(x0,conf);
 % Generate time axis (0-500 samples)
 t = (0:500)';
 s = zeros(1,length(t));
-d = driving_function_imp_wfs(x0,xs,src,conf);
+% t0 is a time offset (delay) added by the driving function
+[d,~,~,t0] = driving_function_imp_wfs(x0,xs,src,conf);
 % If desired a cosine shaped pulse instead of the default dirac pulse could be
 % used
 % d = convolution(d,hann_window(5,5,10));
 for ii = 1:length(t)
     if showprogress, progress_bar(ii,length(t)); end
     % calculate sound field at the listener position
-    p = sound_field_imp(X(1),X(2),X(3),x0,greens_function,d,t(ii),conf);
+    p = sound_field_imp(X(1),X(2),X(3),x0,greens_function,d,t(ii)+t0*fs,conf);
     s(ii) = real(p);
 end
 

--- a/SFS_binaural_synthesis/ir_nfchoa.m
+++ b/SFS_binaural_synthesis/ir_nfchoa.m
@@ -1,7 +1,7 @@
-function [ir,x0] = ir_nfchoa(X,phi,xs,src,sofa,conf)
+function [ir,x0,delay] = ir_nfchoa(X,phi,xs,src,sofa,conf)
 %IR_NFCHOA generates a binaural simulation of NFCHOA
 %
-%   Usage: [ir,x0] = ir_nfchoa(X,phi,xs,src,sofa,conf)
+%   Usage: [ir,x0,delay] = ir_nfchoa(X,phi,xs,src,sofa,conf)
 %
 %   Input parameters:
 %       X       - listener position / m
@@ -16,6 +16,7 @@ function [ir,x0] = ir_nfchoa(X,phi,xs,src,sofa,conf)
 %   Output parameters:
 %       ir      - impulse response for the desired HOA synthesis (nx2 matrix)
 %       x0      - secondary sources
+%       delay   - delay added by driving function / s
 %
 %   IR_NFCHOA(X,phi,xs,src,L,sofa,conf) calculates a binaural room impulse
 %   response for a virtual source at xs for a virtual NFCHOA array and a
@@ -74,6 +75,6 @@ x0 = secondary_source_positions(conf);
 
 %% ===== BRIR ===========================================================
 % Calculate driving function
-d = driving_function_imp_nfchoa(x0,xs,src,conf);
+[d,~,delay] = driving_function_imp_nfchoa(x0,xs,src,conf);
 % Generate the impulse response for NFCHOA
 ir = ir_generic(X,phi,x0,d,sofa,conf);

--- a/SFS_binaural_synthesis/ir_wfs.m
+++ b/SFS_binaural_synthesis/ir_wfs.m
@@ -1,22 +1,23 @@
-function [ir,x0] = ir_wfs(X,phi,xs,src,sofa,conf)
+function [ir,x0,delay] = ir_wfs(X,phi,xs,src,sofa,conf)
 %IR_WFS generates a binaural simulation of WFS
 %
-%   Usage: [ir,x0] = ir_wfs(X,phi,xs,src,sofa,conf)
+%   Usage: [ir,x0,delay] = ir_wfs(X,phi,xs,src,sofa,conf)
 %
 %   Input parameters:
-%       X       - listener position / m
-%       phi     - listener direction [head orientation] / rad
-%                 0 means the head is oriented towards the x-axis.
-%       xs      - virtual source position / m
-%       src     - source type: 'pw' -plane wave
-%                              'ps' - point source
-%                              'fs' - focused source
-%       sofa    - impulse response data set for the secondary sources
-%       conf    - configuration struct (see SFS_config)
+%       X        - listener position / m
+%       phi      - listener direction [head orientation] / rad
+%                  0 means the head is oriented towards the x-axis.
+%       xs       - virtual source position / m
+%       src      - source type: 'pw' -plane wave
+%                               'ps' - point source
+%                               'fs' - focused source
+%       sofa     - impulse response data set for the secondary sources
+%       conf     - configuration struct (see SFS_config)
 %
 %   Output parameters:
-%       ir      - impulse response for the desired WFS array (nx2 matrix)
-%       x0      - secondary sources / m
+%       ir       - impulse response for the desired WFS array (nx2 matrix)
+%       x0       - secondary sources / m
+%       delay    - delay added by driving function / s
 %
 %   IR_WFS(X,phi,xs,src,sofa,conf) calculates a binaural room impulse
 %   response for a virtual source at xs for a virtual WFS array and a
@@ -67,12 +68,16 @@ if conf.debug
 end
 
 
+%% ===== Configuration ===================================================
+fs = conf.fs;
+
+
 %% ===== Computation =====================================================
 % Get secondary sources
 x0 = secondary_source_positions(conf);
 x0 = secondary_source_selection(x0,xs,src);
 x0 = secondary_source_tapering(x0,conf);
 % Get driving signals
-d = driving_function_imp_wfs(x0,xs,src,conf);
+[d,~,~,delay] = driving_function_imp_wfs(x0,xs,src,conf);
 % Generate the impulse response for WFS
 ir = ir_generic(X,phi,x0,d,sofa,conf);

--- a/SFS_config.m
+++ b/SFS_config.m
@@ -180,6 +180,22 @@ conf.xref = [0 0 0]; % / m
 conf.usetapwin = true; % boolean
 % Size of the tapering window
 conf.tapwinlen = 0.3; % / percent of array length, 0..1
+%
+% === Time Domain Implementation ===
+% Adjust the starting time in time domain driving functions.
+% This can be set to
+%   'system'   - the first secondary source will be active at t=0
+%   'source'   - the virtual source will be active at t=0
+% Setting it to 'system' is most convenient when simulating single sources as
+% you will always see activity in the sound field for t>0. Setting it to
+% 'source' helps you to simulate different sources as you can time align them
+% easily. Note, that for virtual sources outside of the array this can mean you
+% will see no activity inside the listening area until the time has passed, that
+% the virtual source needs from its position until the nearest secondary source.
+% Also note, using 'source' for systems with unbounded listening areas -- e.g.
+% linear arrays -- focussed virtual sources may not be placed arbitrarily
+% far from the secondary sources.
+conf.t0 = 'system'; % string
 
 
 %% ===== Sound Field Simulations =========================================
@@ -250,22 +266,6 @@ conf.wfs.hpreBandwidth_in_Oct = 2; % / octaves
 conf.wfs.hpreIIRorder = 4; % integer
 % desired FIR filter order, results in N+1 taps
 conf.wfs.hpreFIRorder = 128; % even integer
-%
-% === Time Domain Implementation ===
-% Adjust the starting time in WFS-time domain driving functions.
-% This can be set to
-%   'system'   - the first secondary source will be active at t=0
-%   'source'   - the virtual source will be active at t=0
-% Setting it to 'system' is most convenient when simulating single sources as
-% you will always see activity in the sound field for t>0. Setting it to
-% 'source' helps you to simulate different sources as you can time align them
-% easily. Note, that for virtual sources outside of the array this can mean you
-% will see no activity inside the listening area until the time has passed, that
-% the virtual source needs from its position until the nearest secondary source.
-% (Also note, using 'source' for systems with unbounded listening areas, (e.g.
-% linear arrays), focussed virtual sources may not be placed arbitrarily
-% far from the secondary sources.)
-conf.wfs.t0 = 'system'; % string
 
 
 %% ===== Spectral Division Method (SDM) ==================================

--- a/SFS_ir/dummy_irs.m
+++ b/SFS_ir/dummy_irs.m
@@ -63,12 +63,13 @@ isargstruct(conf);
 fs = conf.fs;
 c = conf.c;
 distance = 1;
-dirac_position = round(distance/c*fs);
+dirac_position = 1;
 
 
 %% ===== Computation =====================================================
 ir = zeros(1,2,nsamples);
-% Create dirac pulse
+% Create dirac pulse in first sample as the delay corresponding to the distance
+% is handled by get_ir() later on
 ir(:,:,dirac_position) = 1;
 % Store data
 sofa = SOFAgetConventions('SimpleFreeFieldHRIR');

--- a/SFS_ssr/ssr_brs_nfchoa.m
+++ b/SFS_ssr/ssr_brs_nfchoa.m
@@ -1,8 +1,8 @@
-function brs = ssr_brs_nfchoa(X,phi,xs,src,irs,conf)
+function [brs,delay] = ssr_brs_nfchoa(X,phi,xs,src,irs,conf)
 %SSR_BRS_NFCHOA generates a binaural room scanning (BRS) set for use with the
 %SoundScape Renderer
 %
-%   Usage: brs = ssr_brs_nfchoa(X,phi,xs,src,irs,conf)
+%   Usage: [brs,delay] = ssr_brs_nfchoa(X,phi,xs,src,irs,conf)
 %
 %   Input parameters:
 %       X       - listener position / m
@@ -17,6 +17,7 @@ function brs = ssr_brs_nfchoa(X,phi,xs,src,irs,conf)
 %   Output parameters:
 %       brs     - conf.N x 2*nangles matrix containing all impulse responses (2
 %                 channels) for every angles of the BRS set
+%       delay    - delay added by driving function / s
 %
 %   SSR_BRS_NFCHOA(X,phi,xs,src,irs,conf) prepares a BRS set for a virtual
 %   source at position xs for a virtual loudspeaker array driven by
@@ -70,6 +71,6 @@ isargstruct(conf);
 % Secondary sources
 x0 = secondary_source_positions(conf);
 % Calculate driving function
-d = driving_function_imp_nfchoa(x0,xs,src,conf);
+[d,~,delay] = driving_function_imp_nfchoa(x0,xs,src,conf);
 % Calculate brs set
 brs = ssr_brs(X,phi,x0,d,irs,conf);

--- a/SFS_ssr/ssr_brs_wfs.m
+++ b/SFS_ssr/ssr_brs_wfs.m
@@ -1,8 +1,8 @@
-function brs = ssr_brs_wfs(X,phi,xs,src,irs,conf)
+function [brs,delay] = ssr_brs_wfs(X,phi,xs,src,irs,conf)
 %SSR_BRS_WFS generates a binaural room scanning (BRS) set for use with the
 %SoundScape Renderer
 %
-%   Usage: brs = ssr_brs_wfs(X,phi,xs,src,irs,conf)
+%   Usage: [brs,delay] = ssr_brs_wfs(X,phi,xs,src,irs,conf)
 %
 %   Input parameters:
 %       X       - listener position / m
@@ -17,6 +17,7 @@ function brs = ssr_brs_wfs(X,phi,xs,src,irs,conf)
 %   Output parameters:
 %       brs     - conf.N x 2*nangles matrix containing all impulse responses (2
 %                 channels) for every angles of the BRS set
+%       delay   - delay added by driving function / s
 %
 %   SSR_BRS_WFS(X,phi,xs,src,irs,conf) prepares a BRS set for a virtual source
 %   at xs for WFS and the given listener position. One way to use this BRS set
@@ -68,6 +69,6 @@ isargstruct(conf);
 % Secondary sources
 x0 = secondary_source_positions(conf);
 % Calculate driving function
-d = driving_function_imp_wfs(x0,xs,src,conf);
+[d,~,~,delay] = driving_function_imp_wfs(x0,xs,src,conf);
 % Calculate brs set
 brs = ssr_brs(X,phi,x0,d,irs,conf);

--- a/SFS_time_domain/driving_function_imp_wfs.m
+++ b/SFS_time_domain/driving_function_imp_wfs.m
@@ -72,7 +72,7 @@ isargstruct(conf);
 fs = conf.fs;
 N = conf.N;
 c = conf.c;
-t0 = conf.wfs.t0;
+t0 = conf.t0;
 
 
 %% ===== Computation =====================================================

--- a/SFS_time_domain/sound_field_imp_nfchoa.m
+++ b/SFS_time_domain/sound_field_imp_nfchoa.m
@@ -82,13 +82,15 @@ if strcmp('2D',conf.dimension)
 else
     greens_function = 'ps';
 end
-
+fs = conf.fs;
 
 %% ===== Computation =====================================================
 % Get secondary sources
 x0 = secondary_source_positions(conf);
 % Calculate driving function
-d = driving_function_imp_nfchoa(x0,xs,src,conf);
+[d, ~, delay_offset] = driving_function_imp_nfchoa(x0,xs,src,conf);
+% Ensure virtual source/secondary source activity starts at t = 0
+t = t + delay_offset*fs;
 % Calculate sound field
 [varargout{1:min(nargout,4)}] = ...
     sound_field_imp(X,Y,Z,x0,greens_function,d,t,conf);

--- a/doc/binaural-simulations.rst
+++ b/doc/binaural-simulations.rst
@@ -137,6 +137,79 @@ reflections. Note, that the head orientation is chosen to be ``0``
 instead of ``pi/2`` as in the |HRTF| examples due to a difference in the
 orientation of the coordinate system of the |BRIR| measurement.
 
+Impulse response of your spatial audio system
+---------------------------------------------
+
+Binaural simulations are also an interesting approach to investigate the
+behavior of a given spatial audio system at different listener positions. Here, we
+are mainly interested in the influence of the system and not the |HRTF|\ s so we
+simply use a Dirac impulse as |HRTF| as provided by ``dummy_irs()``.
+
+.. sourceode:: matlab
+
+    conf = SFS_config;
+    conf.t0 = 'source';
+    X = [0 0 0];
+    phi = 0;
+    xs = [2.5 0 0];
+    src = 'ps';
+    hrtf = dummy_irs(conf);
+    [ir,~,delay] = ir_wfs(X,phi,xs,src,hrtf,conf);
+    figure;
+    figsize(540,404,'px');
+    plot(ir(1:1000,1),'-g');
+    hold on;
+    offset = round(delay*conf.fs);
+    plot(ir(1+offset:1000+offset,1),'-b');
+    hold off;
+    %print_png('img/impulse_response_wfs_25d.png');
+
+.. figure:: img/impulse_response_wfs_25d.png
+   :align: center
+
+   Sound pressure of an impulse synthesized as a point source by 2.5D |WFS| at
+   (2.5, 0, 0) m. The sound pressure is observed by a virtual microphone at (0,
+   0, 0) m. The impulse is plotted including the delay offset of the WFS driving
+   function (green) and with a corrected delay that corresponds to the source
+   poisition (blue).
+
+The figure includes two versions of the impulse response at two different time
+instances. The green impulse response includes the processing delay that is
+added by `driving_function_imp_wfs()` and other functions performing filtering
+and delaying of signals. This delay is returned by `ir_wfs()` as well and can be
+used to correct it during plotting. The blue impulse response is the corrected
+one, which is now placed at 321 samples which corresponds to the actual distance
+of the synthesized source of 2.5 m.
+
+The impulse response can also be calculated without involving functions for
+binaural simulations, but by utilizing directly `sound_field_imp()` related
+function.
+
+.. sourcecode:: matlab
+
+    conf = SFS_config;
+	conf.N = 1000;
+    conf.t0 = 'source';
+    X = [0 0 0];
+    phi = 0;
+    xs = [2.5 0 0];
+    src = 'ps';
+	time_response_wfs(X,xs,src,conf)
+    %print_png('img/impulse_response_wfs_25d_imp.png');
+
+.. figure:: img/impulse_response_wfs_25d.png
+   :align: center
+
+   Sound pressure of an impulse synthesized as a point source by 2.5D
+   |WFS| at (2.5, 0, 0) m. The sound pressure is observed by a virtual
+   microphone at (0, 0, 0) m.
+
+This time the delay offset of the driving function is automatically corrected
+for and the involved calculation uses inherently a fractional delay filter. The
+downside is that the calculation takes longer and the amplitude is slightly
+lower by the involved fractional delay method.
+
+
 Frequency response of your spatial audio system
 -----------------------------------------------
 
@@ -168,9 +241,9 @@ the figure).
     legend('w/o pre-filter','w pre-filter');
     xlabel('frequency / Hz');
     ylabel('magnitude / dB');
-    %print_png('img/impulse_response_wfs_25d.png');
+    %print_png('img/frequency_response_wfs_25d.png');
 
-.. figure:: img/impulse_response_wfs_25d.png
+.. figure:: img/frequency_response_wfs_25d.png
    :align: center
 
    Sound pressure in decibel of a point source synthesized by 2.5D |WFS| for
@@ -185,9 +258,9 @@ the whole frequency range will be affected.
 
     freq_response_wfs([0 0 0],[0 2.5 0],'ps',conf);
     axis([10 20000 -40 0]);
-    %print_png('img/impulse_response_wfs_25d_mono.png');
+    %print_png('img/frequency_response_wfs_25d_mono.png');
 
-.. figure:: img/impulse_response_wfs_25d_mono.png
+.. figure:: img/frequency_response_wfs_25d_mono.png
    :align: center
 
    Sound pressure in decibel of a point source synthesized by 2.5D |WFS| for

--- a/doc/img/generate_plots.m
+++ b/doc/img/generate_plots.m
@@ -177,7 +177,7 @@ conf.plot.usedb = true;
 plot_sound_field(p,[-2 2],[-2 2],0,x0,conf);
 print_png('sound_field_imp_nfchoa_25d_dB.png');
 conf.plot.useplot = false;
-conf.wfs.t0 = 'source';
+conf.t0 = 'source';
 t_40cm = round(0.4/conf.c*conf.fs); % in samples
 [p_ps,~,~,~,x0_ps] = ...
     sound_field_imp_wfs([-2 2],[-2 2],0,[1.9 0 0],'ps',20+t_40cm,conf);

--- a/doc/img/generate_plots.m
+++ b/doc/img/generate_plots.m
@@ -213,7 +213,26 @@ sound_field_imp_nfchoa(X,Y,0,[0 2 0],'ps',200,conf);
 print_png('sound_field_imp_nfchoa_25d_dB_custom_grid.png');
 
 
-%% ===== impulse response of the system ==================================
+%% ===== impulse response of a spatial audio system ======================
+conf = SFS_config;
+conf.t0 = 'source';
+X = [0 0 0];
+phi = 0;
+xs = [2.5 0 0];
+src = 'ps';
+hrtf = dummy_irs(conf);
+[ir,~,delay] = ir_wfs(X,phi,xs,src,hrtf,conf);
+figure;
+figsize(540,404,'px');
+plot(ir(1:1000,1),'-g');
+hold on;
+offset = round(delay*conf.fs);
+plot(ir(1+offset:1000+offset,1),'-b');
+hold off;
+print_png('img/impulse_response_wfs_25d.png');
+
+
+%% ===== frequency response of a spatial audio system ====================
 conf = SFS_config;
 conf.ir.usehcomp = 0;
 conf.wfs.usehpre = 0;
@@ -232,7 +251,7 @@ set(gca,'XTick',[10 100 250 1000 5000 20000]);
 legend('w/o pre-filter','w pre-filter');
 xlabel('frequency / Hz');
 ylabel('magnitude / dB');
-print_png('impulse_response_wfs_25d.png');
+print_png('frequency_response_wfs_25d.png');
 % alternative variant
 conf = SFS_config;
 [a,f] = freq_response_wfs([0 0 0],[0 2.5 0],'ps',conf);
@@ -244,5 +263,5 @@ set(gca,'XTick',[10 100 250 1000 5000 20000]);
 legend('w pre-filter');
 xlabel('frequency / Hz');
 ylabel('magnitude / dB');
-print_png('impulse_response_wfs_25d_mono.png');
+print_png('frequency_response_wfs_25d_mono.png');
 

--- a/doc/time-domain.rst
+++ b/doc/time-domain.rst
@@ -54,12 +54,12 @@ If you want to simulate more than one virtual source, it is a good idea
 to set the starting time of your simulation to start with the activity
 of your virtual source and not with the secondary sources, which is the
 default behavior. You can change this by setting
-``conf.wfs.t0 = 'source'``.
+``conf.t0 = 'source'``.
 
 .. sourcecode:: matlab
 
     conf.plot.useplot = false;
-    conf.wfs.t0 = 'source';
+    conf.t0 = 'source';
     t_40cm = round(0.4/conf.c*conf.fs); % in samples
     [p_ps,~,~,~,x0_ps] = ...
         sound_field_imp_wfs([-2 2],[-2 2],0,[1.9 0 0],'ps',20+t_40cm,conf);

--- a/validation/test_driving_functions_imp_with_delay.m
+++ b/validation/test_driving_functions_imp_with_delay.m
@@ -1,6 +1,6 @@
 function status = test_driving_functions_imp_with_delay(modus)
 %TEST_DRIVING_FUNCTIONS_IMP_WITH_DELAY tests the correctness of the time-domain
-%driving functions, in the case of conf.wfs.t0 = 'source'
+%driving functions, in the case of conf.t0 = 'source'
 %
 %   Usage: status = test_driving_functions_imp_with_delay(modus)
 %
@@ -13,7 +13,7 @@ function status = test_driving_functions_imp_with_delay(modus)
 %
 %   TEST_DRIVING_FUNCTIONS_IMP_WITH_DELAY(MODUS) checks if the functions,
 %   that calculates the WFS driving functions in time-domain work correctly
-%   for the setting conf.wfs.t0 = 'source'.
+%   for the setting conf.t0 = 'source'.
 %   Therefore different sound fields are simulated.
 
 %*****************************************************************************
@@ -58,7 +58,7 @@ narginchk(nargmin,nargmax);
 
 %% ===== Configuration ===================================================
 conf = SFS_config;
-conf.wfs.t0 = 'source';
+conf.t0 = 'source';
 conf.secondary_sources.size = 3;
 conf.plot.useplot = false;
 conf.plot.usenormalisation = true;
@@ -87,8 +87,11 @@ scenarios = { ...
     'WFS', '2.5D', 'box',      'ps', [ 2.0  2.0  0.0]; ...
     'WFS', '2.5D', 'box',      'fs', [ 0.5  0.5  0.0 -1.0  -1.0  0.0]; ...
     'WFS', '3D',   'sphere',   'ps', [ 0.0  2.5  0.0]; ...
+    'WFS', '3D',   'sphere',   'ls', [ 0.0  2.5  0.0  0.0  1.0  1.0]; ...
     'WFS', '3D',   'sphere',   'pw', [ 0.0 -1.0  0.0]; ...
     'WFS', '3D',   'sphere',   'fs', [ 0.0  0.5  0.0  0.0 -1.0  0.0]; ...
+    'HOA', '2.5D', 'circular', 'pw', [ 0.5  0.5  0.0]; ...
+    'HOA', '2.5D', 'circular', 'ps', [ 0.0  2.5  0.0]; ...
 };
 
 % Start testing
@@ -140,22 +143,40 @@ for ii=1:size(scenarios)
     end
 
     % ===== WFS ==========================================================
-    % spatio-temporal impulse response
-    try
-        [p,x,y,z,x0] = sound_field_imp_wfs(X,Y,Z,xs,src,t,conf);
-        if modus
-            conf.plot.normalisation = 'max';
-            plot_sound_field(p,X,Y,Z,x0,conf);
-            title_str = sprintf('WFS %s %s array, %s, impulse response', ...
-                conf.dimension,conf.secondary_sources.geometry,src);
-            title(title_str);
+    if strcmp('WFS',scenarios{ii,1})
+        % spatio-temporal impulse response
+        try
+            [p,x,y,z,x0] = sound_field_imp_wfs(X,Y,Z,xs,src,t,conf);
+            if modus
+                conf.plot.normalisation = 'max';
+                plot_sound_field(p,X,Y,Z,x0,conf);
+                title_str = sprintf('WFS %s %s array, %s, impulse response', ...
+                    conf.dimension,conf.secondary_sources.geometry,src);
+                title(title_str);
+            end
+        catch
+            warning('%s: WFS impulse response %s array %s %s gives the following error message.', ...
+                upper(mfilename),conf.secondary_sources.geometry,conf.dimension,src);
+            lasterr
         end
-    catch
-        warning('%s: WFS impulse response %s array %s %s gives the following error message.', ...
-            upper(mfilename),conf.secondary_sources.geometry,conf.dimension,src);
-        lasterr
+    % ===== NFC-HOA ======================================================
+    elseif strcmp('HOA',scenarios{ii,1})
+        % spatio-temporal impulse response
+        try
+            [p,x,y,z,x0] = sound_field_imp_nfchoa(X,Y,Z,xs,src,t,conf);
+            if modus
+                conf.plot.normalisation = 'max';
+                plot_sound_field(p,X,Y,Z,x0,conf);
+                title_str = sprintf('NFC-HOA %s %s array, %s, impulse response', ...
+                    conf.dimension,conf.secondary_sources.geometry,src);
+                title(title_str);
+            end
+        catch
+            warning('%s: NFC-HOA impulse response %s array %s %s gives the following error message.', ...
+                upper(mfilename),conf.secondary_sources.geometry,conf.dimension,src);
+            lasterr
+        end
     end
-
 end
 
 


### PR DESCRIPTION
This is a follow up on #113 and deals only with the delay of the impulses.

Try the following code:
```matlab
conf = SFS_config;
X = [0 0 0];
phi = 0;
xs = [2.5 0 0];
src = 'ps';
hrtf = dummy_irs(conf);
% Using an impulse response
ir = ir_wfs(X,phi,xs,src,hrtf,conf);
% Using sound_field_imp() for every time step
[s,t] = time_response_wfs(X,xs,src,conf);
figure;
plot(0:700,ir(1:701,:),'-g');
hold on
plot(t,s,'-b');
grid;
xlabel('samples');
hold off;
```

Before the result was

![current](https://cloud.githubusercontent.com/assets/173624/20800501/01979d3e-b7e6-11e6-97d2-5464ffb050b4.png)

The desired time delay of the first wave front is 321 samples corresponding to a distance of 2.5 m of the virtual point source. The blue impulse response created with `time_response_wfs()` is shifted to the left by the delay offset from the WFS driving function due to the time reversal in `sound_field_imp()`. The green impulse response is shifted to the right by the same delay. This is not a new discovery, see #62, but we have corrected it only [inside `sound_field_imp_wfs()`](https://github.com/sfstoolbox/sfs-matlab/blob/master/SFS_time_domain/sound_field_imp_wfs.m#L100) so far.

This pull request now also corrects it in `time_response_wfs()` and `ir_wfs()`. Running the code from above now results in

![fixed](https://cloud.githubusercontent.com/assets/173624/20800653/85fc0a56-b7e6-11e6-914a-4d8629a7f019.png)

@VeraE, @fietew: is it desireable to fix this delay at all inside `ir_wfs()`? Or would it be better to add it two times inside `time_response_wfs()` to correct for the difference? 