### PR TITLE
Update usage of bandpass in sound_field_imp()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 2.3.0 ()
+    - change default value of conf.usebandpass to false
     - rename conf.wfs.t0 to conf.t0
     - add delay_offset as return value to NFC-HOA time domain driving funtions
     - correct absolute amplitude values of WFS in time domain

--- a/SFS_config.m
+++ b/SFS_config.m
@@ -97,10 +97,6 @@ conf.showprogress = false; % boolean
 conf.fs = 44100; % / Hz
 % Speed of sound
 conf.c = 343; % / m/s
-% Bandpass filter applied in sound_field_imp()
-conf.usebandpass = true; % boolean
-conf.bandpassflow = 10; % / Hz
-conf.bandpassfhigh = 20000; % / Hz
 
 
 %% ===== Delayline =======================================================
@@ -196,6 +192,10 @@ conf.tapwinlen = 0.3; % / percent of array length, 0..1
 % linear arrays -- focussed virtual sources may not be placed arbitrarily
 % far from the secondary sources.
 conf.t0 = 'system'; % string
+% Bandpass filter applied in sound_field_imp()
+conf.usebandpass = true; % boolean
+conf.bandpassflow = 10; % / Hz
+conf.bandpassfhigh = 20000; % / Hz
 
 
 %% ===== Sound Field Simulations =========================================

--- a/SFS_config.m
+++ b/SFS_config.m
@@ -193,7 +193,7 @@ conf.tapwinlen = 0.3; % / percent of array length, 0..1
 % far from the secondary sources.
 conf.t0 = 'system'; % string
 % Bandpass filter applied in sound_field_imp()
-conf.usebandpass = true; % boolean
+conf.usebandpass = false; % boolean
 conf.bandpassflow = 10; % / Hz
 conf.bandpassfhigh = 20000; % / Hz
 


### PR DESCRIPTION
This is a follow up of #113.

At the moment we have the default config setting:
```Matlab
conf.usebandpass = true;
conf.bandpassflow = 10;
conf.bandpassfhigh = 20000;
```
This setting results in an execution of the following line inside `sound_field_imp()`:
```Matlab
d = bandpass(d,bandpassflow,bandpassfhigh,conf);
```
in `bandpass()` the function `fir2()` is used to create the filter and applied by `convolution()`.

`sound_field_imp()` is the only place where the bandpass filtering is applied at the moment.

This pull request should figure out, why we have enabled the bandpass filtering as the **default setting** and if we can disable as default or even remove it.