### PR TITLE
Correct g0 for 2.5D WFS point source and focussed source

### DIFF
--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
@@ -179,14 +179,12 @@ elseif strcmp('2.5D',dimension)
         % r = |x0-xs|
         r = vector_norm(x0-xs,2);
         % 2.5D correction factor
-        %         _____________________
-        %        |      |xref-x0|
-        % g0 = _ |---------------------
-        %       \|||xref-x0| - |xs-x0||
+        %         ___________________
+        %        |     |xref-x0|
+        % g0 = _ |-------------------
+        %       \||xref-x0| + |xs-x0|
         %
-        % Verheijen (1997), eq. (A.14)
-        %
-        g0 = sqrt( vector_norm(xref-x0,2) ./ abs(vector_norm(x0-xref,2) - r) );
+        g0 = sqrt( vector_norm(xref-x0,2) ./ abs(vector_norm(x0-xref,2) + r) );
         %                       ___     ___
         %                      | 1     |-iw  (xs-x0) nx0
         % D_2.5D(x0,w) = g0  _ |---  _ |--- ------------- e^(i w/c |x0-xs|)

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
@@ -184,7 +184,7 @@ elseif strcmp('2.5D',dimension)
         % g0 = _ |-------------------
         %       \||xref-x0| + |xs-x0|
         %
-        g0 = sqrt( vector_norm(xref-x0,2) ./ abs(vector_norm(x0-xref,2) + r) );
+        g0 = sqrt( vector_norm(xref-x0,2) ./ (vector_norm(xref-x0,2) + r) );
         %                       ___     ___
         %                      | 1     |-iw  (xs-x0) nx0
         % D_2.5D(x0,w) = g0  _ |---  _ |--- ------------- e^(i w/c |x0-xs|)

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
@@ -208,11 +208,9 @@ elseif strcmp('2.5D',dimension)
         %
         % 2.5D correction factor
         %        ______________________
-        % g0 = \| d_ref / (d_ref - d_s)
+        % g0 = \| d_ref / (d_ref + d_s)
         %
-        % See Start (1997), eq. (3.16)
-        %
-        g0 = sqrt( dref ./ (dref - ds) );
+        g0 = sqrt( dref ./ (dref + ds) );
         %                       ___     ___
         %                      | 1     |-iw  (xs-x0) nx0
         % D_2.5D(x0,w) = g0  _ |---  _ |--- ------------- e^(i w/c |x0-xs|)

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ps.m
@@ -187,8 +187,6 @@ elseif strcmp('2.5D',dimension)
         % g0 = _ |---------------------
         %       \| |xref-x0| + |x0-xs|
         %
-        % See Start (1997), eq. (3.11)
-        %
         g0 = sqrt( vector_norm(xref-x0,2) ./ (vector_norm(xref-x0,2) + r) );
         %
         % D_2.5D(x0,w) =

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ps.m
@@ -215,11 +215,9 @@ elseif strcmp('2.5D',dimension)
         %
         % 2.5D correction factor
         %        _______________________
-        % g0 = \| d_ref / (d_ref - d_s)
+        % g0 = \| d_ref / (d_ref + d_s)
         %
-        % See Start (1997), eq. (3.16)
-        %
-        g0 = sqrt( dref ./ (dref - ds) );
+        g0 = sqrt( dref ./ (dref + ds) );
         %
         % D_2.5D(x0,w) =
         %       ___    ___

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
@@ -140,7 +140,7 @@ elseif strcmp('2.5D',dimension)
         % g0 = _ |-------------------
         %       \||xref-x0| + |xs-x0|
         %
-        g0 = sqrt( vector_norm(xref-x0,2) ./ abs(vector_norm(x0-xref,2) + r) );
+        g0 = sqrt( vector_norm(xref-x0,2) ./ (vector_norm(xref-x0,2) + r);
         %                                  ___
         %                                 | 1    (xs-x0) nx0
         % d_2.5D(x0,t) = h_pre(-t) * g0 _ |---  ------------- delta(t+|x0-xs|/c)

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
@@ -163,11 +163,9 @@ elseif strcmp('2.5D',dimension)
         %
         % 2.5D correction factor
         %        _______________________
-        % g0 = \| d_ref / (d_ref - d_s)
+        % g0 = \| d_ref / (d_ref + d_s)
         %
-        % See Start (1997), eq. (3.16)
-        %
-        g0 = sqrt( dref / (dref - ds));
+        g0 = sqrt( dref / (dref + ds));
         %                                  ___
         %                                 | 1    (xs-x0) nx0
         % d_2.5D(x0,t) = h_pre(-t) * g0 _ |---  ------------- delta(t+|x0-xs|/c)

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
@@ -135,14 +135,12 @@ elseif strcmp('2.5D',dimension)
         % r = |x0-xs|
         r = vector_norm(x0-xs,2);
         % 2.5D correction factor
-        %         _____________________
-        %        |      |xref-x0|
-        % g0 = _ |---------------------
-        %       \|||xref-x0| - |xs-x0||
+        %         ___________________
+        %        |     |xref-x0|
+        % g0 = _ |-------------------
+        %       \||xref-x0| + |xs-x0|
         %
-        % See Verheijen (1997), eq. (A.14)
-        %
-        g0 = sqrt( vector_norm(xref-x0,2) ./ abs(vector_norm(x0-xref,2) - r) );
+        g0 = sqrt( vector_norm(xref-x0,2) ./ abs(vector_norm(x0-xref,2) + r) );
         %                                  ___
         %                                 | 1    (xs-x0) nx0
         % d_2.5D(x0,t) = h_pre(-t) * g0 _ |---  ------------- delta(t+|x0-xs|/c)

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
@@ -136,8 +136,6 @@ elseif strcmp('2.5D',dimension)
          % g0 = _ |---------------------
          %       \| |xref-x0| + |x0-xs|
          %
-         % See Start (1997), eq. (3.11)
-         %
          g0 = sqrt( vector_norm(xref-x0,2) ./ (vector_norm(x0-xref,2) + r) );
          %                                 ___
          %                                | 1    (x0-xs) nx0

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
@@ -136,7 +136,7 @@ elseif strcmp('2.5D',dimension)
          % g0 = _ |---------------------
          %       \| |xref-x0| + |x0-xs|
          %
-         g0 = sqrt( vector_norm(xref-x0,2) ./ (vector_norm(x0-xref,2) + r) );
+         g0 = sqrt( vector_norm(xref-x0,2) ./ (vector_norm(xref-x0,2) + r) );
          %                                 ___
          %                                | 1    (x0-xs) nx0
          % d_2.5D(x0,t) = h_pre(t) * g0 _ |---  ------------- delta(t-|x0-xs|/c)

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
@@ -161,11 +161,9 @@ elseif strcmp('2.5D',dimension)
          %
          % 2.5D correction factor
          %        _______________________
-         % g0 = \| d_ref / (d_ref - d_s)
+         % g0 = \| d_ref / (d_ref + d_s)
          %
-         % See Start (1997), eq. (3.16)
-         %
-         g0 = sqrt( dref ./ (dref - ds) );
+         g0 = sqrt( dref ./ (dref + ds) );
          %                                 ___
          %                                | 1    (x0-xs) nx0
          % d_2.5D(x0,t) = h_pre(t) * g0 _ |---  ------------- delta(t-|x0-xs|/c)


### PR DESCRIPTION
Looking at the definition of g0 for a point source [using a reference point](http://sfstoolbox.org/en/latest/#equation-D.wfs.ps.2.5D) and [using a reference line](http://sfstoolbox.org/en/latest/#equation-D.wfs.ps.2.5D.refline) and comparing those to the definitions provided in Start (1997) eq. (3.16) or Verheijen (1997) eq. (A.14) there seems to be a mismatched in the sign:
```Latex
\sqrt(\frac{\xref}{\xref-\xs})
```
vs.
```Latex
\sqrt(\frac{\xref}{\xref+\xs})
```

This pull request changes our implementation to be in line with the documentation at http://sfstoolbox.org, which is in line with Schultz (2016).

@fs446 could you please have a look, if this pull request is the correct implementation or if the implementation before was correct, but not the documentation?