### PR TITLE
fix wfs_fs bug and nfchoa gains

### DIFF
--- a/SFS_time_domain/driving_function_imp_nfchoa.m
+++ b/SFS_time_domain/driving_function_imp_nfchoa.m
@@ -94,16 +94,16 @@ for n=1:order+1
     % Get the second-order sections for the different virtual sources
     if strcmp('pw',src)
         % === Plane wave =================================================
-        sos = driving_function_imp_nfchoa_pw(n-1,R,conf);
+        [sos,g] = driving_function_imp_nfchoa_pw(n-1,R,conf);
     elseif strcmp('ps',src)
         % === Point source ===============================================
-        sos = driving_function_imp_nfchoa_ps(n-1,R,r_src,conf);
+        [sos,g] = driving_function_imp_nfchoa_ps(n-1,R,r_src,conf);
     elseif strcmp('ls',src)
         % === Line source ================================================
-        sos = driving_function_imp_nfchoa_ls(n-1,R,r_src,conf);
+        [sos,g] = driving_function_imp_nfchoa_ls(n-1,R,r_src,conf);
     elseif strcmp('fs',src)
         % === Focussed source ============================================
-        sos = driving_function_imp_nfchoa_fs(n-1,R,r_src,conf);
+        [sos,g] = driving_function_imp_nfchoa_fs(n-1,R,r_src,conf);
     else
         error('%s: %s is not a known source type.',upper(mfilename),src);
     end
@@ -113,6 +113,7 @@ for n=1:order+1
     for ii=1:length(b)
         dm(n,:) = filter(b{ii},a{ii},dm(n,:));
     end
+    dm(n,:) = dm(n,:)*g;  % apply gain factor
 end
 
 % Delay_offset
@@ -151,7 +152,7 @@ for l=1:N
 end
 d = circshift(d,[-order,0]);
 d = ifft(transpose(d),[],2);
-d = 1/(2*pi)/R*nls*real(d);
+d = 1/(2*pi*R)*nls*real(d);
 
 % -------------------------------------------------------------------------
 % The following is the direct implementation of the spatial IDFT which
@@ -166,5 +167,5 @@ if(0)
         end
         d(:,n) = transpose(dtemp);
     end
-    d = 1/(2*pi)/R*real(d);
+    d = 1/(2*pi*R)*real(d);
 end

--- a/SFS_time_domain/driving_function_imp_nfchoa.m
+++ b/SFS_time_domain/driving_function_imp_nfchoa.m
@@ -89,7 +89,7 @@ xs(1:3) = xs(1:3)-X0;
 
 % Compute impulse responses of modal filters
 dm = [repmat(pulse,[order+1 1]) zeros(order+1,N-length(pulse))];
-for n=2:order+1
+for n=1:order+1
 
     % Get the second-order sections for the different virtual sources
     if strcmp('pw',src)
@@ -151,7 +151,7 @@ for l=1:N
 end
 d = circshift(d,[-order,0]);
 d = ifft(transpose(d),[],2);
-d = 1/pi/R*nls*real(d);
+d = 1/(2*pi)/R*nls*real(d);
 
 % -------------------------------------------------------------------------
 % The following is the direct implementation of the spatial IDFT which
@@ -166,5 +166,5 @@ if(0)
         end
         d(:,n) = transpose(dtemp);
     end
-    d = 1/pi/R*real(d);
+    d = 1/(2*pi)/R*real(d);
 end

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_fs.m
@@ -1,4 +1,4 @@
-function sos = driving_function_imp_nfchoa_fs(N,R,r,conf)
+function [sos,g] = driving_function_imp_nfchoa_fs(N,R,r,conf)
 %DRIVING_FUNCTION_IMP_NFCHOA_FS calculates the second-order section
 %representation for a virtual focused source in NFC-HOA
 %
@@ -12,6 +12,7 @@ function sos = driving_function_imp_nfchoa_fs(N,R,r,conf)
 %
 %   Output parameters:
 %       sos     - second-order section representation
+%       g       - scalar gain factor
 %
 %   DRIVING_FUNCTION_IMP_NFCHOA_FS(N,R,r,conf) returns the second-order section
 %   representation for the NFC-HOA driving function for a virtual focused source

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ls.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ls.m
@@ -1,4 +1,4 @@
-function sos = driving_function_imp_nfchoa_ls(N,R,r,conf)
+function [sos,g] = driving_function_imp_nfchoa_ls(N,R,r,conf)
 %DRIVING_FUNCTION_IMP_NFCHOA_LS calculates the second-order section
 %representation for a virtual line source in NFC-HOA
 %
@@ -12,6 +12,7 @@ function sos = driving_function_imp_nfchoa_ls(N,R,r,conf)
 %
 %   Output parameters:
 %       sos     - second-order section representation
+%       g       - scalar gain factor
 %
 %   DRIVING_FUNCTION_IMP_NFCHOA_LS(N,R,r,conf) returns the second-order section
 %   representation for the NFC-HOA driving function for a virtual line source

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
@@ -97,6 +97,7 @@ elseif strcmp('2.5D',dimension)
         % 2.5D using a point source as source model
         %
         [sos,~] = zp2sos(z*c/r,z*c/R,1,'up','none');
+        sos(1,1:3) = sos(1,1:3) * R/r;
         %
         % Compare Spors et al. (2011), eq. (11)
         %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
@@ -1,4 +1,4 @@
-function sos = driving_function_imp_nfchoa_ps(N,R,r,conf)
+function [sos,g] = driving_function_imp_nfchoa_ps(N,R,r,conf)
 %DRIVING_FUNCTION_IMP_NFCHOA_PS calculates the second-order section
 %representation for a virtual point source in NFC-HOA
 %
@@ -12,6 +12,7 @@ function sos = driving_function_imp_nfchoa_ps(N,R,r,conf)
 %
 %   Output parameters:
 %       sos     - second-order section representation
+%       g       - scalar gain factor
 %
 %   DRIVING_FUNCTION_IMP_NFCHOA_PS(N,R,r,conf) returns the second-order section
 %   representation for the NFC-HOA driving function for a virtual point source
@@ -96,8 +97,8 @@ elseif strcmp('2.5D',dimension)
         % --- SFS Toolbox ------------------------------------------------
         % 2.5D using a point source as source model
         %
-        [sos,~] = zp2sos(z*c/r,z*c/R,1,'up','none');
-        sos(1,1:3) = sos(1,1:3) * R/r;
+        [sos,g] = zp2sos(z*c/r,z*c/R,1,'up','none');
+        g = g * R/r;
         %
         % Compare Spors et al. (2011), eq. (11)
         %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
@@ -96,7 +96,7 @@ elseif strcmp('2.5D',dimension)
         % 2.5D for a plane wave as source model
         %
         [sos,~] = zp2sos(p,z*c/R,2,'down','none');
-        sos(1,1:3) = sos(1,1:3) * (-1)^abs(N);
+        sos(1,1:3) = sos(1,1:3) * (-1)^abs(N) * 4*pi * R;
         %
         % Compare Spors et al. (2011), eq. (10)
         %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
@@ -1,4 +1,4 @@
-function sos = driving_function_imp_nfchoa_pw(N,R,conf)
+function [sos,g] = driving_function_imp_nfchoa_pw(N,R,conf)
 %DRIVING_FUNCTION_IMP_NFCHOA_PW calculates the second-order section
 %representation for a virtual plane wave in NFC-HOA
 %
@@ -11,6 +11,7 @@ function sos = driving_function_imp_nfchoa_pw(N,R,conf)
 %
 %   Output parameters:
 %       sos     - second-order section representation
+%       g       - scalar gain factor
 %
 %   DRIVING_FUNCTION_IMP_NFCHOA_PW(N,R,conf) returns the second-order section
 %   representation for the NFC-HOA driving function for a virtual plane wave
@@ -95,8 +96,8 @@ elseif strcmp('2.5D',dimension)
         % --- SFS Toolbox ------------------------------------------------
         % 2.5D for a plane wave as source model
         %
-        [sos,~] = zp2sos(p,z*c/R,2,'down','none');
-        sos(1,1:3) = sos(1,1:3) * (-1)^abs(N) * 4*pi * R;
+        [sos, g] = zp2sos(p,z*c/R,1,'down','none');
+        g = g * (-1)^abs(N) * 4*pi * R;
         %
         % Compare Spors et al. (2011), eq. (10)
         %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
@@ -169,7 +169,7 @@ elseif strcmp('2.5D',dimension)
         %
         % See Start (1997), eq. (3.16)
         %
-        g0 = sqrt( dref / (dref - ds));
+        g0 = sqrt( dref ./ (dref - ds));
         %                                  ___
         %                                 | 1    (xs-x0) nx0
         % d_2.5D(x0,t) = h_pre(-t) * g0 _ |---  ------------- delta(t+|x0-xs|/c)

--- a/validation/test_imp_25d.m
+++ b/validation/test_imp_25d.m
@@ -1,0 +1,132 @@
+function status = test_imp_25d(modus)
+%TEST_imp_25D tests behavior of 2.5D SFS techniques in time-domain
+%
+%   Usage: status = test_imp_25d(modus)
+%
+%   Input parameters:
+%       modus   - 0: numerical
+%                 1: visual
+%
+%   Output parameters:
+%       status  - true or false
+
+%*****************************************************************************
+% The MIT License (MIT)                                                      *
+%                                                                            *
+% Copyright (c) 2010-2016 SFS Toolbox Developers                             *
+%                                                                            *
+% Permission is hereby granted,  free of charge,  to any person  obtaining a *
+% copy of this software and associated documentation files (the "Software"), *
+% to deal in the Software without  restriction, including without limitation *
+% the rights  to use, copy, modify, merge,  publish, distribute, sublicense, *
+% and/or  sell copies of  the Software,  and to permit  persons to whom  the *
+% Software is furnished to do so, subject to the following conditions:       *
+%                                                                            *
+% The above copyright notice and this permission notice shall be included in *
+% all copies or substantial portions of the Software.                        *
+%                                                                            *
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+% IMPLIED, INCLUDING BUT  NOT LIMITED TO THE  WARRANTIES OF MERCHANTABILITY, *
+% FITNESS  FOR A PARTICULAR  PURPOSE AND  NONINFRINGEMENT. IN NO EVENT SHALL *
+% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+% LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT, TORT  OR OTHERWISE, ARISING *
+% FROM,  OUT OF  OR IN  CONNECTION  WITH THE  SOFTWARE OR  THE USE  OR OTHER *
+% DEALINGS IN THE SOFTWARE.                                                  *
+%                                                                            *
+% The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
+% methods like wave field synthesis or higher order ambisonics.              *
+%                                                                            *
+% http://sfstoolbox.org                                 sfstoolbox@gmail.com *
+%*****************************************************************************
+
+
+status = false;
+
+
+%% ===== Checking of input  parameters ===================================
+nargmin = 1;
+nargmax = 1;
+narginchk(nargmin,nargmax);
+
+%% ===== Configuration ===================================================
+% Parameters
+conf = SFS_config;
+conf.secondary_sources.geometry = 'linear';
+conf.xref = [0,0,0];
+conf.dimension = '2.5D';
+conf.plot.useplot = false;
+conf.wfs.hpreflow = 20;
+conf.wfs.hprefhigh = 20000;
+
+% test scenarios
+scenarios = { ...
+  'WFS', 'reference_point', 'linear', 'pw', [ 0.0 -1.0   0.0]
+  'WFS', 'reference_point', 'linear', 'ps', [ 0.0  2.5   0.0]
+  'WFS', 'reference_point', 'linear', 'fs', [ 0.0  0.75  0.0  0.0 -1.0  0.0]
+  'WFS', 'reference_line' , 'linear', 'pw', [ 0.0 -1.0   0.0]
+  'WFS', 'reference_line' , 'linear', 'ps', [ 0.0  2.5   0.0]
+  'WFS', 'reference_line' , 'linear', 'fs', [ 0.0  0.75  0.0  0.0 -1.0  0.0]
+  'HOA', 'default', 'circular', 'pw', [ 0.0 -1.0   0.0]
+  'HOA', 'default', 'circular', 'ps', [ 0.0  2.5  0.0]
+  };
+
+%% ===== Main ============================================================
+
+sofa = dummy_irs(512, conf);
+xt = conf.xref + [0.1, 0, 0];
+
+for ii=1:size(scenarios)
+  
+  src = scenarios{ii, 4};  %
+  xs = scenarios{ii, 5};  % source position
+  
+  % get listening area
+  conf.secondary_sources.geometry = scenarios{ii,3};
+  switch scenarios{ii,3}
+    case 'linear'
+      conf.secondary_sources.size = 4;
+      conf.secondary_sources.number = 56;
+      % conf.usetapwin = true;
+      % conf.tapwinlen = 0.2;
+      conf.secondary_sources.center = [0, 1.5, 0];
+    case 'circular'
+      conf.secondary_sources.size = 1.5;
+      conf.secondary_sources.number = 56;
+      conf.secondary_sources.center = [0, 0, 0];
+  end
+  x0 = secondary_source_positions(conf);
+  
+  % compute driving signals
+  conf.driving_functions = scenarios{ii, 2};
+  switch scenarios{ii,1}
+    case 'WFS'
+      x0 = secondary_source_selection(x0, xs, src);
+      x0 = secondary_source_tapering(x0, conf);
+      d = driving_function_imp_wfs(x0, xs, src, conf);
+    case 'HOA'
+      d = driving_function_imp_nfchoa(x0, xs, src, conf);
+  end
+  
+  % spectrum of reproduced sound field at reference position
+  ir_sfs = ir_generic(xt,0,x0,d, sofa, conf);
+  [IR_sfs, ~, f_sfs] = spectrum_from_signal(ir_sfs(:,1),conf);
+  
+  % spectrum of ground truth sound field at reference position
+  if strcmp(src, 'pw')
+    ir_gt = ir_point_source(xt, 0, -xs./norm(xs) ,sofa,conf);
+    ir_gt = ir_gt*4*pi;
+  else
+    ir_gt = ir_point_source(xt, 0, xs(1:3),sofa,conf);
+  end
+  [IR_gt, ~, f_gt] = spectrum_from_signal(ir_gt(:,1),conf);
+  
+  if modus    
+    figure;
+    semilogx(f_sfs, db(IR_sfs), 'r', f_gt, db(IR_gt), 'b--');
+    title(sprintf('%s %s %s', scenarios{ii,1}, src,conf.driving_functions), ...
+      'Interpreter','none');
+    legend('reproduced','ground truth','Location','northwest');
+  end  
+end
+
+status = true;

--- a/validation/test_imp_25d.m
+++ b/validation/test_imp_25d.m
@@ -51,7 +51,6 @@ narginchk(nargmin,nargmax);
 %% ===== Configuration ===================================================
 % Parameters
 conf = SFS_config;
-conf.secondary_sources.geometry = 'linear';
 conf.xref = [0,0,0];
 conf.dimension = '2.5D';
 conf.plot.useplot = false;
@@ -85,13 +84,13 @@ for ii=1:size(scenarios)
   switch scenarios{ii,3}
     case 'linear'
       conf.secondary_sources.size = 4;
-      conf.secondary_sources.number = 56;
-      % conf.usetapwin = true;
-      % conf.tapwinlen = 0.2;
+      conf.secondary_sources.number = 128;
+      conf.usetapwin = true;
+      conf.tapwinlen = 0.2;
       conf.secondary_sources.center = [0, 1.5, 0];
     case 'circular'
       conf.secondary_sources.size = 1.5;
-      conf.secondary_sources.number = 56;
+      conf.secondary_sources.number = 128;
       conf.secondary_sources.center = [0, 0, 0];
   end
   x0 = secondary_source_positions(conf);


### PR DESCRIPTION
According to the original publication ( see https://doi.org/10.1109/ASPAA.2011.6082325 ), Equation (10) and (11), some weights are missing in our NFCHOA time-domain implementation for the plane waves and point source. This pull request fixes this.

Execute ``test_imp_25d(true)`` to compare the spectra of 2.5D SFS techniques near the reference point with the ground truth (plane wave or point source).

There was also a bug in ``SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m`` related to a wrong usage of the ``/``-operator.