### PR TITLE
use persistent variables to speed up resampling filter

### DIFF
--- a/SFS_general/delayline.m
+++ b/SFS_general/delayline.m
@@ -105,16 +105,15 @@ switch delay.resampling
     case 'pm'
         % === Parks-McClellan linear phase FIR filter ===
         rfactor = delay.resamplingfactor;
+        rfilt = pm_filter(rfactor*delay.resamplingorder, 0.9/rfactor, ...
+          1/rfactor);        
         delay_offset = delay.resamplingorder*rfactor / 2;
-        A = [1 1 0 0];
-        f = [0.0 0.9/rfactor 1/rfactor 1.0];
-        rfilt = rfactor*firpm(delay.resamplingorder*rfactor,f,A);
 
         sig = reshape(sig,1,channels*samples);
         sig = [sig; zeros(rfactor-1,channels*samples)];
         sig = reshape(sig,rfactor*samples,channels);
 
-        sig = filter(rfilt,1,sig,[],1);
+        sig = convolution(rfactor*rfilt, sig);
     otherwise
         error('%s: "%s": unknown resampling method',upper(mfilename), ...
             delay.resampling);

--- a/SFS_general/pm_filter.m
+++ b/SFS_general/pm_filter.m
@@ -1,12 +1,12 @@
-function b = pm_filter(order,Wpass,Wstop)
+function b = pm_filter(order,wpass,wstop)
 %PM_FILTER computes an FIR lowpass-filter using the Parks-McClellan Algorithm
 %
-%   Usage: b = pm_filter(order,Wpass,Wstop)
+%   Usage: b = pm_filter(order,wpass,wstop)
 %
 %   Input parameter:
 %     order   - order N of filter in original (not upsampled) domain
-%     Wpass   - normalised frequency [0..1] 
-%     Wstop   - normalised frequency [0..1]
+%     wpass   - last normalised passband frequency [0..1] 
+%     wstop   - first normalised stopband frequency [0..1]
 %
 %   Output parameter:
 %     b   - filter coefficients / [(order+1) x 1]
@@ -50,15 +50,15 @@ persistent pmCachedWstop
 persistent pmCachedCoefficients
 
 if isempty(pmCachedOrder) || pmCachedOrder ~= order ...
-    || isempty(pmCachedWpass) || pmCachedWpass ~= Wpass ...
-    || isempty(pmCachedWstop) || pmCachedWstop ~= Wstop
+    || isempty(pmCachedWpass) || pmCachedWpass ~= wpass ...
+    || isempty(pmCachedWstop) || pmCachedWstop ~= wstop
   
   A = [1 1 0 0];
-  f = [0.0 Wpass Wstop 1.0]; 
+  f = [0.0 wpass wstop 1.0]; 
   
   pmCachedOrder = order;
-  pmCachedWpass = Wpass;
-  pmCachedWstop = Wstop;
+  pmCachedWpass = wpass;
+  pmCachedWstop = wstop;
   pmCachedCoefficients = firpm(order,f,A).';
 end
   

--- a/SFS_general/pm_filter.m
+++ b/SFS_general/pm_filter.m
@@ -1,7 +1,7 @@
-function b = pm_filter(order, Wpass, Wstop)
-%PM_Filter computes an FIR lowpass-filter using the Parks-McClellan Algorithm
+function b = pm_filter(order,Wpass,Wstop)
+%PM_FILTER computes an FIR lowpass-filter using the Parks-McClellan Algorithm
 %
-%   Usage: b = pm_filter(order, Wpass, Wstop)
+%   Usage: b = pm_filter(order,Wpass,Wstop)
 %
 %   Input parameter:
 %     order   - order N of filter in original (not upsampled) domain
@@ -44,7 +44,6 @@ function b = pm_filter(order, Wpass, Wstop)
 
 
 %% ===== Computation =====================================================
-
 persistent pmCachedOrder
 persistent pmCachedWpass
 persistent pmCachedWstop

--- a/SFS_general/pm_filter.m
+++ b/SFS_general/pm_filter.m
@@ -1,0 +1,66 @@
+function b = pm_filter(order, Wpass, Wstop)
+%PM_Filter computes an FIR lowpass-filter using the Parks-McClellan Algorithm
+%
+%   Usage: b = pm_filter(order, Wpass, Wstop)
+%
+%   Input parameter:
+%     order   - order N of filter in original (not upsampled) domain
+%     Wpass   - normalised frequency [0..1] 
+%     Wstop   - normalised frequency [0..1]
+%
+%   Output parameter:
+%     b   - filter coefficients / [(order+1) x 1]
+%
+%   See also: delayline, thiran_filter
+
+%*****************************************************************************
+% The MIT License (MIT)                                                      *
+%                                                                            *
+% Copyright (c) 2010-2016 SFS Toolbox Developers                             *
+%                                                                            *
+% Permission is hereby granted,  free of charge,  to any person  obtaining a *
+% copy of this software and associated documentation files (the "Software"), *
+% to deal in the Software without  restriction, including without limitation *
+% the rights  to use, copy, modify, merge,  publish, distribute, sublicense, *
+% and/or  sell copies of  the Software,  and to permit  persons to whom  the *
+% Software is furnished to do so, subject to the following conditions:       *
+%                                                                            *
+% The above copyright notice and this permission notice shall be included in *
+% all copies or substantial portions of the Software.                        *
+%                                                                            *
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+% IMPLIED, INCLUDING BUT  NOT LIMITED TO THE  WARRANTIES OF MERCHANTABILITY, *
+% FITNESS  FOR A PARTICULAR  PURPOSE AND  NONINFRINGEMENT. IN NO EVENT SHALL *
+% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+% LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT, TORT  OR OTHERWISE, ARISING *
+% FROM,  OUT OF  OR IN  CONNECTION  WITH THE  SOFTWARE OR  THE USE  OR OTHER *
+% DEALINGS IN THE SOFTWARE.                                                  *
+%                                                                            *
+% The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
+% methods like wave field synthesis or higher order ambisonics.              *
+%                                                                            *
+% http://sfstoolbox.org                                 sfstoolbox@gmail.com *
+%*****************************************************************************
+
+
+%% ===== Computation =====================================================
+
+persistent pmCachedOrder
+persistent pmCachedWpass
+persistent pmCachedWstop
+persistent pmCachedCoefficients
+
+if isempty(pmCachedOrder) || pmCachedOrder ~= order ...
+    || isempty(pmCachedWpass) || pmCachedWpass ~= Wpass ...
+    || isempty(pmCachedWstop) || pmCachedWstop ~= Wstop
+  
+  A = [1 1 0 0];
+  f = [0.0 Wpass Wstop 1.0]; 
+  
+  pmCachedOrder = order;
+  pmCachedWpass = Wpass;
+  pmCachedWstop = Wstop;
+  pmCachedCoefficients = firpm(order,f,A).';
+end
+  
+b = pmCachedCoefficients;


### PR DESCRIPTION
MATLAB's profiler told me, that the design of the resampling filter which is done in ``firpm`` for each ``delayline`` call takes at lot of time. This fix caches the filter coefficients in a persistent variable.