### PR TITLE
Enable shortcut for exact point

### DIFF
--- a/SFS_ir/get_ir.m
+++ b/SFS_ir/get_ir.m
@@ -141,7 +141,7 @@ if strcmp('SimpleFreeFieldHRIR',header.GLOBAL_SOFAConventions)
     ir = ir_correct_distance(ir,x0(idx,3),xs(3),conf);
     [x0(:,1),x0(:,2),x0(:,3)] = sph2cart(x0(:,1),x0(:,2),x0(:,3));
     % Select or interpolate to desired impulse response
-    ir = interpolate_ir(ir,weights,x0(idx,:),conf);
+    ir = interpolate_ir(ir,weights,conf);
 
 elseif strcmp('MultiSpeakerBRIR',header.GLOBAL_SOFAConventions)
     %
@@ -182,7 +182,7 @@ elseif strcmp('MultiSpeakerBRIR',header.GLOBAL_SOFAConventions)
     ir = sofa_get_data_fire(sofa,idx_head,idx_emitter);
     ir = reshape(ir,[size(ir,1) size(ir,2) size(ir,4)]); % [M R E N] => [M R N]
     % Select or interpolate to desired impulse response
-    ir = interpolate_ir(ir,weights,sofa_head_orientations(idx_head,:),conf);
+    ir = interpolate_ir(ir,weights,conf);
 
 elseif strcmp('SingleRoomDRIR',header.GLOBAL_SOFAConventions)
     %

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -1,7 +1,7 @@
-function ir_new = interpolate_ir(ir,weights,x0,conf)
+function ir = interpolate_ir(ir,weights,x0,conf)
 %INTERPOLATE_IR interpolates the given impulse responses according to their weights
 %
-%   Usage: ir_new = interpolate_ir(ir,weights,x0,conf)
+%   Usage: ir = interpolate_ir(ir,weights,x0,conf)
 %
 %   Input parameters:
 %       ir           - matrix containing impulse responses in the form [M C N], where
@@ -13,7 +13,7 @@ function ir_new = interpolate_ir(ir,weights,x0,conf)
 %       conf         - configuration struct (see SFS_config)
 %
 %   Output parameters:
-%       ir_new       - impulse response for the given position [1 C N]
+%       ir           - impulse response for the given position [1 C N]
 %
 %   INTERPOLATE_IR(ir,weights,x0,conf) interpolates the given impulse responses
 %   by applying the given weights and returns the interpolated impulse response.
@@ -99,12 +99,10 @@ weights = weights(weights>=prec);
 x0 = x0(weights>=prec,:);
 
 % === IR interpolation ===
-if ~useinterpolation || length(weights)==1
-    ir_new = ir;
-elseif useinterpolation
+if useinterpolation && length(weights)>1
     switch interpolationmethod
     case 'simple'
-        ir_new = sum(bsxfun(@times,ir,weights),1);
+        ir = sum(bsxfun(@times,ir,weights),1);
     case 'freqdomain'
         % See Itoh (1982), Hartung et al. (1999)
         %
@@ -116,10 +114,10 @@ elseif useinterpolation
         % Calculate interpolation only for the first half of the spectrum
         % and only for original bins
         idx_half = floor(size(TF,3)/2)+1;
-        magnitude_new = sum(bsxfun(@times,magnitude(:,:,1:4:idx_half),weights),1);
-        phase_new = sum(bsxfun(@times,phase(:,:,1:4:idx_half),weights),1);
+        magnitude = sum(bsxfun(@times,magnitude(:,:,1:4:idx_half),weights),1);
+        phase = sum(bsxfun(@times,phase(:,:,1:4:idx_half),weights),1);
         % Calculate interpolated impulse response from new magnitude and phase
-        ir_new = ifft(magnitude_new.*exp(1i*phase_new),size(ir,3),3,'symmetric');
+        ir = ifft(magnitude.*exp(1i*phase),size(ir,3),3,'symmetric');
     otherwise
         error('%s: %s is an unknown interpolation method.', ...
             upper(mfilename),interpolationmethod);

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -96,7 +96,6 @@ prec = 0.001;
 % Leave out impulse responses with weights smaller than prec
 ir = ir(weights>=prec,:,:);
 weights = weights(weights>=prec);
-x0 = x0(weights>=prec,:);
 
 % === IR interpolation ===
 if useinterpolation && length(weights)>1

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -15,8 +15,8 @@ function ir_new = interpolate_ir(ir,weights,x0,conf)
 %   Output parameters:
 %       ir_new       - impulse response for the given position [1 C N]
 %
-%   INTERPOLATE_IR(ir,x0,xs,conf) interpolates the given impulse responses by
-%   applying the given weights and returns the interpolated impulse response.
+%   INTERPOLATE_IR(ir,weights,x0,conf) interpolates the given impulse responses
+%   by applying the given weights and returns the interpolated impulse response.
 %   Only impulse responses with weights larger that the precision prec=0.001 will
 %   be used.
 %	The interpolation method differs depending on the setting of

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -1,7 +1,7 @@
-function [ir_new,weights_new,x0_new] = interpolate_ir(ir,weights,x0,conf)
+function ir_new = interpolate_ir(ir,weights,x0,conf)
 %INTERPOLATE_IR interpolates the given impulse responses according to their weights
 %
-%   Usage: [ir_new,weights_new,x0_new] = interpolate_ir(ir,weights,x0,conf)
+%   Usage: ir_new = interpolate_ir(ir,weights,x0,conf)
 %
 %   Input parameters:
 %       ir           - matrix containing impulse responses in the form [M C N], where
@@ -14,15 +14,11 @@ function [ir_new,weights_new,x0_new] = interpolate_ir(ir,weights,x0,conf)
 %
 %   Output parameters:
 %       ir_new       - impulse response for the given position [1 C N]
-%       weights_new  - weights corresponding to impulse responses used for
-%                      interpolation
-%       x0_new       - position corresponding to impulse responses used for
-%                      interpolation
 %
 %   INTERPOLATE_IR(ir,x0,xs,conf) interpolates the given impulse responses by
-%   applying the given weights and returns the interpolated impulse response as
-%   well as its corresponding position. Only impulse responses with weights larger
-%   that the precision prec=0.001 will be used.
+%   applying the given weights and returns the interpolated impulse response.
+%   Only impulse responses with weights larger that the precision prec=0.001 will
+%   be used.
 %	The interpolation method differs depending on the setting of
 %	conf.ir.interpolationmethod:
 %     'simple'      - Interpolation in the time domain performed samplewise.
@@ -99,11 +95,11 @@ prec = 0.001;
 %% ===== Computation ====================================================
 % Leave out impulse responses with weights smaller than prec
 ir = ir(weights>=prec,:,:);
-weights_new = weights(weights>=prec);
-x0_new = x0(weights>=prec,:);
+weights = weights(weights>=prec);
+x0 = x0(weights>=prec,:);
 
 % === IR interpolation ===
-if ~useinterpolation || length(weights_new)==1
+if ~useinterpolation || length(weights)==1
     ir_new = ir;
 elseif useinterpolation
     switch interpolationmethod

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -103,7 +103,7 @@ weights_new = weights(weights>=prec);
 x0_new = x0(weights>=prec,:);
 
 % === IR interpolation ===
-if ~useinterpolation || length(weights)==1
+if ~useinterpolation || length(weights_new)==1
     ir_new = ir;
 elseif useinterpolation
     switch interpolationmethod

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -1,7 +1,7 @@
-function ir = interpolate_ir(ir,weights,x0,conf)
+function ir = interpolate_ir(ir,weights,conf)
 %INTERPOLATE_IR interpolates the given impulse responses according to their weights
 %
-%   Usage: ir = interpolate_ir(ir,weights,x0,conf)
+%   Usage: ir = interpolate_ir(ir,weights,conf)
 %
 %   Input parameters:
 %       ir           - matrix containing impulse responses in the form [M C N], where
@@ -9,13 +9,12 @@ function ir = interpolate_ir(ir,weights,x0,conf)
 %                          C ... Number of channels
 %                          N ... Number of samples
 %       weights      - M weights for impulse reponses
-%       x0           - M positions corresponding to given impulse responses
 %       conf         - configuration struct (see SFS_config)
 %
 %   Output parameters:
 %       ir           - impulse response for the given position [1 C N]
 %
-%   INTERPOLATE_IR(ir,weights,x0,conf) interpolates the given impulse responses
+%   INTERPOLATE_IR(ir,weights,conf) interpolates the given impulse responses
 %   by applying the given weights and returns the interpolated impulse response.
 %   Only impulse responses with weights larger that the precision prec=0.001 will
 %   be used.
@@ -70,8 +69,8 @@ function ir = interpolate_ir(ir,weights,x0,conf)
 
 
 %% ===== Checking of input parameters ===================================
-nargmin = 4;
-nargmax = 4;
+nargmin = 3;
+nargmax = 3;
 narginchk(nargmin,nargmax);
 
 


### PR DESCRIPTION
I had to make a small change so that the interpolation routine is actually skipped when the desired point is contained in the selected points and no interpolation is necessary, that is one weight is 1 and the others are zero.