### PR TITLE
fix incorporation of tapering weights for LWFS

### DIFF
--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_vss.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_vss.m
@@ -83,11 +83,6 @@ else
     error('%s: %s is not a known source type.',upper(mfilename),dimension);
 end
 
-% Adjust weights of secondary sources in order to use the tapering
-% correctly. Integration weights for the secondary sources will be applied
-% later, when the sound field is computed
-x0(:,7) = 1;
-
 % Get driving signals for real secondary sources
 %
 % See Spors (2010), fig. 2 & eq. (12)
@@ -99,9 +94,9 @@ Dmatrix = zeros(N0,Ns);
 for idx=1:Ns
     [xtmp, xdx] = secondary_source_selection(x0,xv(idx,1:6),'fs');
     if (~isempty(xtmp))
-        xtmp = secondary_source_tapering(xtmp,conf);
+        wtap = tapering_window(xtmp,conf);
         Dmatrix(xdx,idx) = ...
-            driving_function_mono_wfs(xtmp,xv(idx,1:3),'fs',f,conf) .* xtmp(:,7);
+            driving_function_mono_wfs(xtmp,xv(idx,1:3),'fs',f,conf) .* wtap;
     end
 end
 

--- a/SFS_time_domain/driving_function_imp_localwfs.m
+++ b/SFS_time_domain/driving_function_imp_localwfs.m
@@ -165,8 +165,7 @@ switch method
         [tau0(xdx,idx),w0(xdx,idx)] = driving_function_imp_wfs_fs( ...
           x0s(:,1:3),x0s(:,4:6),xs,conf);
         % Optional tapering
-        x0tmp = secondary_source_tapering(x0s,conf);
-        wtap = x0tmp(:,7)./x0s(:,7);
+        wtap = tapering_window(x0s,conf);
         % Apply secondary sources' tapering and possibly virtual secondary
         % sources' tapering to weighting matrix
         w0(xdx,idx) = w0(xdx,idx).*wv(idx).*wtap.*xvi(7);

--- a/SFS_time_domain/driving_function_imp_localwfs.m
+++ b/SFS_time_domain/driving_function_imp_localwfs.m
@@ -165,10 +165,11 @@ switch method
         [tau0(xdx,idx),w0(xdx,idx)] = driving_function_imp_wfs_fs( ...
           x0s(:,1:3),x0s(:,4:6),xs,conf);
         % Optional tapering
-        x0s = secondary_source_tapering(x0s,conf);
+        x0tmp = secondary_source_tapering(x0s,conf);
+        wtap = x0tmp(:,7)./x0s(:,7);
         % Apply secondary sources' tapering and possibly virtual secondary
         % sources' tapering to weighting matrix
-        w0(xdx,idx) = w0(xdx,idx).*wv(idx).*x0s(:,7).*xvi(7);
+        w0(xdx,idx) = w0(xdx,idx).*wv(idx).*wtap.*xvi(7);
         % add up delay of secondary sources and virtual secondary sources
         tau0(xdx,idx) = tau0(xdx,idx) + tauv(idx);
       end


### PR DESCRIPTION
As ``x0s(:,7)`` also contains the integration weight of the secondary source, the influence of the tapering has to be computed by normalising the result to the original integration weight.