### PR TITLE
Alternative referencing scheme for focused sources in WFS

### DIFF
--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
@@ -234,6 +234,30 @@ elseif strcmp('2.5D',dimension)
             .* vector_product(xs-x0,nx0,2) ./ r.^(3./2) ...
             .* exp(+1i.*omega./c.*r);
         %
+    case {'reference_circle'}
+        % Driving function with two stationary phase approximations,
+        % reference to circle around the focused source with radius |xref-xs|
+        %
+        % r = |x0-xs|
+        r = vector_norm(x0-xs,2);
+        %
+        % 2.5D correction factor
+        %         _____________
+        %        |        r
+        % g0 = _ |1 + ---------
+        %       \|    |xref-xs|
+        %
+        g0 = sqrt( 1 + r./vector_norm(xref-xs,2) );
+        %                       ___     ___
+        %                      | 1     |-iw  (xs-x0) nx0
+        % D_2.5D(x0,w) = g0  _ |---  _ |--- ------------- e^(i w/c |x0-xs|)
+        %                     \|2pi   \| c  |x0-xs|^(3/2)
+        %
+        % Driving signal
+        D = 1./sqrt(2.*pi) .* sqrt(-1i.*omega./c) .* g0 ...
+            .* vector_product(xs-x0,nx0,2) ./ r.^(3./2) ...
+            .* exp(+1i.*omega./c.*r);
+        %
     case 'legacy'
         % --- Old SFS Toolbox default ------------------------------------
         % 2.5D correction factor

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
@@ -203,6 +203,30 @@ elseif strcmp('2.5D',dimension)
         delay = -1./c .* r;
         weight = g0 ./ sqrt(2.*pi) .* vector_product(xs-x0,nx0,2) ./ r.^(3./2);
         %
+    case {'reference_circle'}
+        % Driving function with two stationary phase approximations,
+        % reference to circle around the focused source with radius |xref-xs|
+        %
+        % r = |x0-xs|
+        r = vector_norm(x0-xs,2);
+        %
+        % 2.5D correction factor
+        %         _____________
+        %        |        r
+        % g0 = _ |1 + ---------
+        %       \|    |xref-xs|
+        %
+        g0 = sqrt( 1 + r./vector_norm(xref-xs,2) );
+        %                                  ___
+        %                                 | 1    (xs-x0) nx0
+        % d_2.5D(x0,t) = h_pre(-t) * g0 _ |---  ------------- delta(t+|x0-xs|/c)
+        %                                \|2pi  |x0-xs|^(3/2)
+        %
+        %
+        % Delay and amplitude weight
+        delay = -1./c .* r;
+        weight = g0 ./ sqrt(2.*pi) .* vector_product(xs-x0,nx0,2) ./ r.^(3./2);
+        %
     case 'legacy'
         % --- SFS Toolbox ------------------------------------------------
         % 2.5D correction factor


### PR DESCRIPTION
I discovered an issue regarding the existing referencing scheme for the focused source in WFS, namely ``reference_point`` and ``reference_line``.

Reference Point:
```
        %         _____________________
        %        |      |xref-x0|
        % g0 = _ |---------------------
        %       \|||xref-x0| - |xs-x0||
```
Reference Line:
```
        %        ______________________
        % g0 = \| d_ref / (d_ref - d_s)
```

Both schemes have the drawback, that the denominator can become zero for non-pathological cases. Hence particular secondary sources have a unreasonably high amplitude. I added a scheme called ``reference_circle`` which ensure amplitude correct synthesis on a circle around the focused source, which does not have these issues. Please execute the following example to compare ``reference_point`` and ``reference_circle``. The green dots in the plots for ``reference_point`` indicate the theoretical coordinates on the circular SSD, where the amplitude of the seconday source is infinity.

```MATLAB
conf = SFS_config;

conf.dimension = '2.5D';

conf.plot.normalisation = 'center';

conf.secondary_sources.geometry = 'circular';
conf.secondary_sources.number = 256;
conf.secondary_sources.size = 3;

conf.t0 = 'source';
conf.usetapwin = false;

X = [-1.55, 1.55];
Y = [-1.55, 1.55];
Z = 0;

xs = [0 0.5 0 -sqrt(0.5) -sqrt(0.5) 0]; 
src = 'fs';
t = norm(xs(1:3) - conf.xref)/conf.c;
f = 1000;

conf.driving_functions = 'reference_point';
conf.plot.usedb = true;
sound_field_imp_wfs(X,Y,Z, xs, src, t, conf);
hold on;
xs(1:3) = xs(1:3) - conf.xref;
[phis, rs] = cart2pol(xs(1), xs(2));
r0 = conf.secondary_sources.size/2;
phi0 = [-1,1]*acos(rs/2/r0) + phis;
plot( conf.xref(1) + r0*cos(phi0), conf.xref(2) + r0*sin(phi0), 'o', 'MarkerFaceColor',[0.0,1.0,0.0] );
hold off;
conf.plot.usedb = false;
sound_field_mono_wfs(X,Y,Z, xs, src, f, conf);
hold on;
xs(1:3) = xs(1:3) - conf.xref;
[phis, rs] = cart2pol(xs(1), xs(2));
r0 = conf.secondary_sources.size/2;
phi0 = [-1,1]*acos(rs/2/r0) + phis;
plot( conf.xref(1) + r0*cos(phi0), conf.xref(2) + r0*sin(phi0), 'o', 'MarkerFaceColor',[0.0,1.0,0.0] );
hold off;

conf.driving_functions = 'reference_circle';
conf.plot.usedb = true;
sound_field_imp_wfs(X,Y,Z, xs, src, t, conf);
conf.plot.usedb = false;
sound_field_mono_wfs(X,Y,Z, xs, src, f, conf);
```