### PR TITLE
Add symmetric_ifft() to fix Octave bug

### DIFF
--- a/SFS_general/modal_weighting.m
+++ b/SFS_general/modal_weighting.m
@@ -114,7 +114,7 @@ end
 
 % Inverse DTFT
 if nargout>1
-    Win = ifft([win,zeros(1,order)],ndtft,'symmetric');
+    Win = symmetric_ifft([win,zeros(1,order)],ndtft);
 end
 % Axis corresponding to inverse DTFT
 if nargout>2

--- a/SFS_general/symmetric_ifft.m
+++ b/SFS_general/symmetric_ifft.m
@@ -1,0 +1,63 @@
+function X = symmetric_ifft(varargin)
+%SYMMETRIC_IFFT computes the inverse discrete Fourier transform of using a
+%Fast Fourier Transform (FFT) algorithm.
+%
+%   Usage: X = symmetric_ifft(Y,[n,[dim]])
+%
+%   Input parameters:
+%       Y       - input signal
+%       n       - number of elements of X to use
+%       dim     - dimension along the ifft should be calculated
+%
+%   Output parameters:
+%       X       - inverse Fourier trafo of X
+%
+%   SYMMETRIC_IFFT(Y,n,dim) calculates the inverse discrete Fourier transform and
+%   treats Y as if it were conjugate symmetric. Internally this calls
+%   ifft(Y,n,dim,'symmetric') in the case of Matlab and real(ifft(Y,n,dim)) in the
+%   case of Octave as there is no check for symmetry available.
+%
+%   See also: ifft, modal_weighting, interpolate_ir
+
+%*****************************************************************************
+% The MIT License (MIT)                                                      *
+%                                                                            *
+% Copyright (c) 2010-2017 SFS Toolbox Developers                             *
+%                                                                            *
+% Permission is hereby granted,  free of charge,  to any person  obtaining a *
+% copy of this software and associated documentation files (the "Software"), *
+% to deal in the Software without  restriction, including without limitation *
+% the rights  to use, copy, modify, merge,  publish, distribute, sublicense, *
+% and/or  sell copies of  the Software,  and to permit  persons to whom  the *
+% Software is furnished to do so, subject to the following conditions:       *
+%                                                                            *
+% The above copyright notice and this permission notice shall be included in *
+% all copies or substantial portions of the Software.                        *
+%                                                                            *
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+% IMPLIED, INCLUDING BUT  NOT LIMITED TO THE  WARRANTIES OF MERCHANTABILITY, *
+% FITNESS  FOR A PARTICULAR  PURPOSE AND  NONINFRINGEMENT. IN NO EVENT SHALL *
+% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+% LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT, TORT  OR OTHERWISE, ARISING *
+% FROM,  OUT OF  OR IN  CONNECTION  WITH THE  SOFTWARE OR  THE USE  OR OTHER *
+% DEALINGS IN THE SOFTWARE.                                                  *
+%                                                                            *
+% The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
+% methods like wave field synthesis or higher order ambisonics.              *
+%                                                                            *
+% http://sfstoolbox.org                                 sfstoolbox@gmail.com *
+%*****************************************************************************
+
+
+% ===== Checking of input parameters ====================================
+nargmin = 1;
+nargmax = 3;
+narginchk(nargmin,nargmax);
+
+
+%% ===== Calculation =====================================================
+if isoctave
+    X = real(ifft(varargin{:}));
+else
+    X = ifft(varargin{:},'symmetric');
+end

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -115,7 +115,7 @@ if useinterpolation && length(weights)>1
         magnitude = sum(bsxfun(@times,magnitude(:,:,1:4:idx_half),weights),1);
         phase = sum(bsxfun(@times,phase(:,:,1:4:idx_half),weights),1);
         % Calculate interpolated impulse response from new magnitude and phase
-        ir = ifft(magnitude.*exp(1i*phase),size(ir,3),3,'symmetric');
+        ir = symmetric_ifft(magnitude.*exp(1i*phase),size(ir,3),3);
     otherwise
         error('%s: %s is an unknown interpolation method.', ...
             upper(mfilename),interpolationmethod);


### PR DESCRIPTION
This is a proposal to solve the Octave bug #133.

This is not really a proper solution, but a workaround as it allows Octave for running through without an error by replacing `ifft(...,'symmetric')` by `real(ifft(...))`.
I don't know yet if it would be desirable to implement the exact same behavior of the Matlab version as `real()` simple disregards the output and is not checking for conjugate symmetric input.