### PR TITLE
Change default 2.5D WFS fs driving function

### DIFF
--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
@@ -177,7 +177,33 @@ elseif strcmp('2.5D',dimension)
     xref = repmat(xref,[size(x0,1) 1]);
 
     switch driving_functions
-    case {'default', 'reference_point'}
+    case {'default', 'reference_circle'}
+        % Driving function with two stationary phase approximations,
+        % reference to circle around the focused source with radius |xref-xs|
+        %
+        % r = |x0-xs|
+        r = vector_norm(x0-xs,2);
+        %
+        % 2.5D correction factor
+        %         _____________
+        %        |        r
+        % g0 = _ |1 + ---------
+        %       \|    |xref-xs|
+        %
+        g0 = sqrt( 1 + r./vector_norm(xref-xs,2) );
+        %                       ___     ___
+        %                      | 1     |-iw  (xs-x0) nx0
+        % D_2.5D(x0,w) = g0  _ |---  _ |--- ------------- e^(i w/c |x0-xs|)
+        %                     \|2pi   \| c  |x0-xs|^(3/2)
+        %
+        % See http://sfstoolbox.org/en/update_wfs_ps/#equation-D.wfs.fs.2.5D
+        %
+        % Driving signal
+        D = 1./sqrt(2.*pi) .* sqrt(-1i.*omega./c) .* g0 ...
+            .* vector_product(xs-x0,nx0,2) ./ r.^(3./2) ...
+            .* exp(+1i.*omega./c.*r);
+        %
+    case 'reference_point'
         % Driving function with only one stationary phase approximation,
         % reference to one point in field
         %
@@ -196,8 +222,6 @@ elseif strcmp('2.5D',dimension)
         %                      | 1     |-iw  (xs-x0) nx0
         % D_2.5D(x0,w) = g0  _ |---  _ |--- ------------- e^(i w/c |x0-xs|)
         %                     \|2pi   \| c  |x0-xs|^(3/2)
-        %
-        % See http://sfstoolbox.org/en/update_wfs_ps/#equation-D.wfs.fs.2.5D
         %
         % Driving signal
         D = 1./sqrt(2.*pi) .* sqrt(-1i.*omega./c) .* g0 ...
@@ -229,30 +253,6 @@ elseif strcmp('2.5D',dimension)
         %
         % r = |x0-xs|
         r = vector_norm(x0-xs,2);
-        % Driving signal
-        D = 1./sqrt(2.*pi) .* sqrt(-1i.*omega./c) .* g0 ...
-            .* vector_product(xs-x0,nx0,2) ./ r.^(3./2) ...
-            .* exp(+1i.*omega./c.*r);
-        %
-    case {'reference_circle'}
-        % Driving function with two stationary phase approximations,
-        % reference to circle around the focused source with radius |xref-xs|
-        %
-        % r = |x0-xs|
-        r = vector_norm(x0-xs,2);
-        %
-        % 2.5D correction factor
-        %         _____________
-        %        |        r
-        % g0 = _ |1 + ---------
-        %       \|    |xref-xs|
-        %
-        g0 = sqrt( 1 + r./vector_norm(xref-xs,2) );
-        %                       ___     ___
-        %                      | 1     |-iw  (xs-x0) nx0
-        % D_2.5D(x0,w) = g0  _ |---  _ |--- ------------- e^(i w/c |x0-xs|)
-        %                     \|2pi   \| c  |x0-xs|^(3/2)
-        %
         % Driving signal
         D = 1./sqrt(2.*pi) .* sqrt(-1i.*omega./c) .* g0 ...
             .* vector_product(xs-x0,nx0,2) ./ r.^(3./2) ...

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
@@ -148,7 +148,32 @@ elseif strcmp('2.5D',dimension)
     xref = repmat(xref,[size(x0,1) 1]);
 
     switch driving_functions
-    case {'default', 'reference_point'}
+    case {'default', 'reference_circle'}
+        % Driving function with two stationary phase approximations,
+        % reference to circle around the focused source with radius |xref-xs|
+        %
+        % r = |x0-xs|
+        r = vector_norm(x0-xs,2);
+        %
+        % 2.5D correction factor
+        %         _____________
+        %        |        r
+        % g0 = _ |1 + ---------
+        %       \|    |xref-xs|
+        %
+        g0 = sqrt( 1 + r./vector_norm(xref-xs,2) );
+        %                                  ___
+        %                                 | 1    (xs-x0) nx0
+        % d_2.5D(x0,t) = h_pre(-t) * g0 _ |---  ------------- delta(t+|x0-xs|/c)
+        %                                \|2pi  |x0-xs|^(3/2)
+        %
+        % See http://sfstoolbox.org/#equation-d.wfs.fs.2.5D
+        %
+        % Delay and amplitude weight
+        delay = -1./c .* r;
+        weight = g0 ./ sqrt(2.*pi) .* vector_product(xs-x0,nx0,2) ./ r.^(3./2);
+        %
+    case 'reference_point'
         % Driving function with only one stationary phase approximation,
         % reference to one point in field
         %
@@ -167,8 +192,6 @@ elseif strcmp('2.5D',dimension)
         %                                 | 1    (xs-x0) nx0
         % d_2.5D(x0,t) = h_pre(-t) * g0 _ |---  ------------- delta(t+|x0-xs|/c)
         %                                \|2pi  |x0-xs|^(3/2)
-        %
-        % See http://sfstoolbox.org/#equation-d.wfs.fs.2.5D
         %
         % Delay and amplitude weight
         delay = -1./c .* r;
@@ -199,30 +222,6 @@ elseif strcmp('2.5D',dimension)
         %
         % r = |x0-xs|
         r = vector_norm(x0-xs,2);
-        % Delay and amplitude weight
-        delay = -1./c .* r;
-        weight = g0 ./ sqrt(2.*pi) .* vector_product(xs-x0,nx0,2) ./ r.^(3./2);
-        %
-    case {'reference_circle'}
-        % Driving function with two stationary phase approximations,
-        % reference to circle around the focused source with radius |xref-xs|
-        %
-        % r = |x0-xs|
-        r = vector_norm(x0-xs,2);
-        %
-        % 2.5D correction factor
-        %         _____________
-        %        |        r
-        % g0 = _ |1 + ---------
-        %       \|    |xref-xs|
-        %
-        g0 = sqrt( 1 + r./vector_norm(xref-xs,2) );
-        %                                  ___
-        %                                 | 1    (xs-x0) nx0
-        % d_2.5D(x0,t) = h_pre(-t) * g0 _ |---  ------------- delta(t+|x0-xs|/c)
-        %                                \|2pi  |x0-xs|^(3/2)
-        %
-        %
         % Delay and amplitude weight
         delay = -1./c .* r;
         weight = g0 ./ sqrt(2.*pi) .* vector_product(xs-x0,nx0,2) ./ r.^(3./2);


### PR DESCRIPTION
This is a follow up on #146 which introduced a fix for the 2.5D reference scheme in 2.5D as the current default implementation has the problem of possible division by 0. The resulting problems can be seen by running `test_localwfs_vss(1)` or by executing the example provided in #146.

As the proposed solution of a reference circle includes the point solution, which is currently implemented with `conf.xref` it should be ok to switch the default to this, even if the documentation is not up to date with it and we will have a new referencing scheme in 2.5 anyhow, see #136.

@fietew: if you agree with this, please "rebase and merge". If it would include more work, I would propose to postpone it also to the release 2.5.