### PR TITLE
add monochromatic version of LWFS-SBL

### DIFF
--- a/SFS_analysis/freq_response_localwfs_sbl.m
+++ b/SFS_analysis/freq_response_localwfs_sbl.m
@@ -87,6 +87,11 @@ x0 = secondary_source_positions(conf);
 % Generate frequencies (10^1-10^4.3)
 f = logspace(0,4.3,N)';
 S = zeros(size(f));
+% set default value for conf.localwfs_sbl.Npw
+if isempty(conf.localwfs_sbl.Npw)
+    conf.localwfs_sbl.Npw = ...
+        2*ceil(2*pi*max(f)/conf.c*conf.secondary_sources.size/2);
+end
 % Get the result for all frequencies
 for ii = 1:length(f)
     if showprogress, progress_bar(ii,length(f)); end

--- a/SFS_analysis/freq_response_localwfs_sbl.m
+++ b/SFS_analysis/freq_response_localwfs_sbl.m
@@ -1,8 +1,8 @@
-function varargout = freq_response_localwfs(X,xs,src,conf)
-%FREQ_RESPONSE_WFS simulates the frequency response for WFS at the given
+function varargout = freq_response_localwfs_sbl(X,xs,src,conf)
+%FREQ_RESPONSE_LOCALWFS_SBL simulates the frequency response for WFS at the given
 %listener position
 %
-%   Usage: [S,f] = freq_response_wfs(X,xs,src,conf)
+%   Usage: [S,f] = freq_response_loaclwfs_sbl(X,xs,src,conf)
 %
 %   Input parameters:
 %       X           - listener position / m
@@ -17,9 +17,9 @@ function varargout = freq_response_localwfs(X,xs,src,conf)
 %       S           - simulated frequency response
 %       f           - corresponding frequency axis / Hz
 %
-%   FREQ_RESPONSE_LOCALWFS(X,xs,src,conf) simulates the frequency response of a
-%   the source type src placed at xs and synthesized by local WFS at the given
-%   virtual microphone position X.
+%   FREQ_RESPONSE_LOCALWFS_SBL(X,xs,src,conf) simulates the frequency response
+%   of a source synthesized by local WFS using spatial bandwith limitation
+%   (SBL) at the given virtual microphone position X.
 %   The length in samples of the frequency response is given by conf.N. The
 %   actual calculation is done via sound_field_mono() and a loop over frequency
 %   f.
@@ -67,6 +67,7 @@ isargstruct(conf);
 
 
 %% ===== Configuration ==================================================
+N = conf.N;
 showprogress = conf.showprogress;
 useplot = conf.plot.useplot;
 % Check type of secondary sources to use
@@ -82,14 +83,14 @@ end
 conf.showprogress = false;
 conf.plot.useplot = false;
 % Get the position of the loudspeakers
-x0_real = secondary_source_positions(conf);
+x0 = secondary_source_positions(conf);
 % Generate frequencies (10^1-10^4.3)
 f = logspace(0,4.3,N)';
 S = zeros(size(f));
 % Get the result for all frequencies
 for ii = 1:length(f)
     if showprogress, progress_bar(ii,length(f)); end
-    [D, x0] = driving_function_mono_localwfs(x0_real,xs,src,f(ii),conf);
+    D = driving_function_mono_localwfs_sbl(x0,xs,src,f(ii),conf);
     % Calculate sound field at the listener position
     P = sound_field_mono(X(1),X(2),X(3),x0,greens_function,D,f(ii),conf);
     S(ii) = abs(P);

--- a/SFS_analysis/freq_response_localwfs_vss.m
+++ b/SFS_analysis/freq_response_localwfs_vss.m
@@ -1,0 +1,112 @@
+function varargout = freq_response_localwfs_vss(X,xs,src,conf)
+%FREQ_RESPONSE_LOCALWFS_VSS simulates the frequency response for local WFS at
+%the given listener position
+%
+%   Usage: [S,f] = freq_response_localwfs_vss(X,xs,src,conf)
+%
+%   Input parameters:
+%       X           - listener position / m
+%       xs          - position of virtual source / m
+%       src         - source type of the virtual source
+%                         'pw' -plane wave
+%                         'ps' - point source
+%                         'fs' - focused source
+%       conf        - configuration struct (see SFS_config)
+%
+%   Output parameters:
+%       S           - simulated frequency response
+%       f           - corresponding frequency axis / Hz
+%
+%   FREQ_RESPONSE_LOCALWFS_VSS(X,xs,src,conf) simulates the frequency response
+%   of a source synthesized by local WFS using virtual secondary sources (VSS)
+%   at the given virtual microphone position X.
+%   The length in samples of the frequency response is given by conf.N. The
+%   actual calculation is done via sound_field_mono() and a loop over frequency
+%   f.
+%
+%   See also: sound_field_mono_localwfs_vss, time_response_localwfs_vss
+
+%*****************************************************************************
+% The MIT License (MIT)                                                      *
+%                                                                            *
+% Copyright (c) 2010-2017 SFS Toolbox Developers                             *
+%                                                                            *
+% Permission is hereby granted,  free of charge,  to any person  obtaining a *
+% copy of this software and associated documentation files (the "Software"), *
+% to deal in the Software without  restriction, including without limitation *
+% the rights  to use, copy, modify, merge,  publish, distribute, sublicense, *
+% and/or  sell copies of  the Software,  and to permit  persons to whom  the *
+% Software is furnished to do so, subject to the following conditions:       *
+%                                                                            *
+% The above copyright notice and this permission notice shall be included in *
+% all copies or substantial portions of the Software.                        *
+%                                                                            *
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+% IMPLIED, INCLUDING BUT  NOT LIMITED TO THE  WARRANTIES OF MERCHANTABILITY, *
+% FITNESS  FOR A PARTICULAR  PURPOSE AND  NONINFRINGEMENT. IN NO EVENT SHALL *
+% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+% LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT, TORT  OR OTHERWISE, ARISING *
+% FROM,  OUT OF  OR IN  CONNECTION  WITH THE  SOFTWARE OR  THE USE  OR OTHER *
+% DEALINGS IN THE SOFTWARE.                                                  *
+%                                                                            *
+% The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
+% methods like wave field synthesis or higher order ambisonics.              *
+%                                                                            *
+% http://sfstoolbox.org                                 sfstoolbox@gmail.com *
+%*****************************************************************************
+
+
+%% ===== Checking of input  parameters ==================================
+nargmin = 4;
+nargmax = 4;
+narginchk(nargmin,nargmax);
+isargposition(X);
+isargxs(xs);
+isargchar(src);
+isargstruct(conf);
+
+
+%% ===== Configuration ==================================================
+N = conf.N;
+showprogress = conf.showprogress;
+useplot = conf.plot.useplot;
+% Check type of secondary sources to use
+if strcmp('2D',conf.dimension)
+    greens_function = 'ls';
+else
+    greens_function = 'ps';
+end
+
+
+%% ===== Computation ====================================================
+% Disable progress bar and plotting for sound_field_imp()
+conf.showprogress = false;
+conf.plot.useplot = false;
+% Get the position of the loudspeakers
+x0_real = secondary_source_positions(conf);
+% Generate frequencies (10^1-10^4.3)
+f = logspace(0,4.3,N)';
+S = zeros(size(f));
+% Get the result for all frequencies
+for ii = 1:length(f)
+    if showprogress, progress_bar(ii,length(f)); end
+    [D, x0] = driving_function_mono_localwfs_vss(x0_real,xs,src,f(ii),conf);
+    % Calculate sound field at the listener position
+    P = sound_field_mono(X(1),X(2),X(3),x0,greens_function,D,f(ii),conf);
+    S(ii) = abs(P);
+end
+
+% Return parameter
+if nargout>0, varargout{1}=S; end
+if nargout>1, varargout{2}=f; end
+
+
+%% ===== Plotting ========================================================
+if nargout==0 || useplot
+    figure;
+    figsize(conf.plot.size(1),conf.plot.size(2),conf.plot.size_unit);
+    semilogx(f,db(S));
+    set(gca,'XTick',[10 100 250 1000 5000 20000]);
+    ylabel('amplitude / dB');
+    xlabel('frequency / Hz');
+end

--- a/SFS_analysis/time_response_localwfs_sbl.m
+++ b/SFS_analysis/time_response_localwfs_sbl.m
@@ -1,0 +1,114 @@
+function varargout = time_response_localwfs_sbl(X,xs,src,conf)
+%TIME_RESPONSE_LOCALWFS_SBL simulates the time response for LOCAL WFS at the
+%given listener position
+%
+%   Usage: [s,t] = time_response_localwfs_sbl(X,xs,src,conf)
+%
+%   Input parameters:
+%       X           - listener position / m
+%       xs          - position of virtual source / m
+%       src         - source type of the virtual source
+%                         'pw' -plane wave
+%                         'ps' - point source
+%                         'fs' - focused source
+%       conf        - configuration struct (see SFS_config)
+%
+%   Output parameters:
+%       s           - simulated time response
+%       t           - corresponding time axis / s
+%
+%   TIME_RESPONSE_LOCALWFS_SBL(X,xs,src,conf) simulates the impulse response of
+%   a source synthesized by local WFS using spatial bandwidth limitation at the
+%   given virtual microphone position X.
+%   The length in samples of the impulse response is given by conf.N. The
+%   actual calculation is done via sound_field_imp() and a loop over time t. A
+%   similar result can be achieved by using ir_localwfs() in combination with
+%   dummy_irs().
+%
+%   See also: ir_localwfs, sound_field_imp, freq_response_localwfs_vss
+
+%*****************************************************************************
+% The MIT License (MIT)                                                      *
+%                                                                            *
+% Copyright (c) 2010-2017 SFS Toolbox Developers                             *
+%                                                                            *
+% Permission is hereby granted,  free of charge,  to any person  obtaining a *
+% copy of this software and associated documentation files (the "Software"), *
+% to deal in the Software without  restriction, including without limitation *
+% the rights  to use, copy, modify, merge,  publish, distribute, sublicense, *
+% and/or  sell copies of  the Software,  and to permit  persons to whom  the *
+% Software is furnished to do so, subject to the following conditions:       *
+%                                                                            *
+% The above copyright notice and this permission notice shall be included in *
+% all copies or substantial portions of the Software.                        *
+%                                                                            *
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+% IMPLIED, INCLUDING BUT  NOT LIMITED TO THE  WARRANTIES OF MERCHANTABILITY, *
+% FITNESS  FOR A PARTICULAR  PURPOSE AND  NONINFRINGEMENT. IN NO EVENT SHALL *
+% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+% LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT, TORT  OR OTHERWISE, ARISING *
+% FROM,  OUT OF  OR IN  CONNECTION  WITH THE  SOFTWARE OR  THE USE  OR OTHER *
+% DEALINGS IN THE SOFTWARE.                                                  *
+%                                                                            *
+% The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
+% methods like wave field synthesis or higher order ambisonics.              *
+%                                                                            *
+% http://sfstoolbox.org                                 sfstoolbox@gmail.com *
+%*****************************************************************************
+
+
+%% ===== Checking of input  parameters ==================================
+nargmin = 4;
+nargmax = 4;
+narginchk(nargmin,nargmax);
+isargposition(X);
+isargxs(xs);
+isargchar(src);
+isargstruct(conf);
+
+
+%% ===== Configuration ==================================================
+fs = conf.fs;
+N = conf.N;
+showprogress = conf.showprogress;
+useplot = conf.plot.useplot;
+% Select secondary source type
+if strcmp('2D',conf.dimension)
+    greens_function = 'ls';
+else
+    greens_function = 'ps';
+end
+
+
+%% ===== Computation ====================================================
+% Disable progress bar and plotting for sound_field_imp()
+conf.showprogress = false;
+conf.plot.useplot = false;
+% Get the position of the loudspeakers
+x0 = secondary_source_positions(conf);
+x0 = secondary_source_selection(x0,xs,src);
+x0 = secondary_source_tapering(x0,conf);
+% Generate time axis
+t = (0:N-1)'/fs;
+s = zeros(1,length(t));
+d = driving_function_imp_localwfs_vss(x0,xs,src,conf);
+for ii = 1:length(t)
+    if showprogress, progress_bar(ii,length(t)); end
+    % Calculate sound field at the listener position
+    p = sound_field_imp(X(1),X(2),X(3),x0,greens_function,d,t(ii),conf);
+    s(ii) = real(p);
+end
+
+% Return parameter
+if nargout>0, varargout{1}=s; end
+if nargout>1, varargout{2}=t; end
+
+
+%% ===== Plotting ========================================================
+if nargout==0 || useplot
+    figure;
+    figsize(conf.plot.size(1),conf.plot.size(2),conf.plot.size_unit);
+    plot(t*1000,s);
+    ylabel('amplitude');
+    xlabel('time / ms');
+end

--- a/SFS_analysis/time_response_localwfs_vss.m
+++ b/SFS_analysis/time_response_localwfs_vss.m
@@ -1,8 +1,8 @@
-function varargout = time_response_localwfs(X,xs,src,conf)
-%TIME_RESPONSE_LOCALWFS simulates the time response for LOCAL WFS at the given
-%listener position
+function varargout = time_response_localwfs_vss(X,xs,src,conf)
+%TIME_RESPONSE_LOCALWFS_VSS simulates the time response for LOCAL WFS at the
+%given listener position
 %
-%   Usage: [s,t] = time_response_localwfs(X,xs,src,conf)
+%   Usage: [s,t] = time_response_localwfs_vss(X,xs,src,conf)
 %
 %   Input parameters:
 %       X           - listener position / m
@@ -17,15 +17,15 @@ function varargout = time_response_localwfs(X,xs,src,conf)
 %       s           - simulated time response
 %       t           - corresponding time axis / s
 %
-%   TIME_RESPONSE_LOCALWFS(X,xs,src,conf) simulates the impulse response of a
-%   the source type src placed at xs and synthesized by local WFS at the given
-%   virtual microphone position X.
+%   TIME_RESPONSE_LOCALWFS_VSS(X,xs,src,conf) simulates the impulse response of
+%   a source synthesized by local WFS using virtual secondary sources (VSS) at
+%   the given virtual microphone position X.
 %   The length in samples of the impulse response is given by conf.N. The
 %   actual calculation is done via sound_field_imp() and a loop over time t. A
 %   similar result can be achieved by using ir_localwfs() in combination with
 %   dummy_irs().
 %
-%   See also: ir_localwfs, sound_field_imp, freq_response_localwfs
+%   See also: ir_localwfs, sound_field_imp, freq_response_localwfs_vss
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *
@@ -91,7 +91,7 @@ x0 = secondary_source_tapering(x0,conf);
 % Generate time axis
 t = (0:N-1)'/fs;
 s = zeros(1,length(t));
-d = driving_function_imp_localwfs(x0,xs,src,conf);
+d = driving_function_imp_localwfs_vss(x0,xs,src,conf);
 for ii = 1:length(t)
     if showprogress, progress_bar(ii,length(t)); end
     % Calculate sound field at the listener position

--- a/SFS_general/inverse_cht.m
+++ b/SFS_general/inverse_cht.m
@@ -63,7 +63,7 @@ N = size(Am,1);
 % Implementation of
 %           ___
 %           \
-% A(phi) =  /__    A  e^(+j*m*n*2*pi/Nphi)
+% A(phi) =  /__    A  e^(+i*m*n*2*pi/Nphi)
 %         m=-M..M   m
 
 % Spatial IFFT

--- a/SFS_general/linkwitz_riley.m
+++ b/SFS_general/linkwitz_riley.m
@@ -54,10 +54,10 @@ function [z,p,k] = linkwitz_riley(n,wc,ftype,domain)
 nargmin = 3;
 nargmax = 4;
 narginchk(nargmin,nargmax);
+isargpositivescalar(n,wc);
 if mod(n,2)
     error('%s: n (%d) is not an even integer.',upper(mfilename),n);
 end
-isargpositivescalar(wc);
 isargchar(ftype)
 if ~any(strcmp(ftype, {'low', 'high', 'all'}))
     error('%s: ftype (%s) is not a supported filter type.',upper(mfilename), ...
@@ -97,4 +97,17 @@ case 'all'
         z = -p;
         k = 1;
     end
+end
+
+% Average complex conjugates to make them exactly symmetrical.
+% This avoids the following Octave bug: http://savannah.gnu.org/bugs/?49996
+if ~isempty(z)
+    [~, idx] = sort(imag(z));
+    z = z(idx);
+    z = 0.5*z + 0.5*conj(z(end:-1:1));
+end
+if ~isempty(p)
+    [~, idx] = sort(imag(p));
+    p = p(idx);
+    p = 0.5*p + 0.5*conj(p(end:-1:1));
 end

--- a/SFS_general/secondary_source_selection.m
+++ b/SFS_general/secondary_source_selection.m
@@ -173,5 +173,5 @@ end
 x0 = x0_tmp(idx,:);
 
 if size(x0,1)==0
-    warning('%s: 0 secondary sources were selected.',upper(mfilename));
+    warning('SFS:x0','%s: 0 secondary sources were selected.',upper(mfilename));
 end

--- a/SFS_general/sphbesselh.m
+++ b/SFS_general/sphbesselh.m
@@ -1,17 +1,17 @@
 function out = sphbesselh(nu,k,z)
-% SPHBESSELH spherical hankel function of order nu, kind k, and argument z
+% SPHBESSELH spherical Hankel function of order nu, kind k, and argument z
 %
 %   Usage: out = sphbesselh(nu,k,z)
 %
 %   Input parameters:
-%       nu  - order of hankel function
-%       k   - kind of hankel function (1 ^= first kind, 2 ^= second kind)
-%       z   - argument of hankel function
+%       nu  - order of Hankel function
+%       k   - kind of Hankel function (1 ^= first kind, 2 ^= second kind)
+%       z   - argument of Hankel function
 %
 %   Output parameters:
-%       out - value of hankel function at point z
+%       out - value of Hankel function at point z
 %
-%   SPHBESSELH(nu,k,z) spherical hankel function of order nu, kind k, and
+%   SPHBESSELH(nu,k,z) spherical Hankel function of order nu, kind k, and
 %   argument z
 %
 %   See also: sphbesselj, sphbessely

--- a/SFS_general/sphbesselh.m
+++ b/SFS_general/sphbesselh.m
@@ -63,4 +63,4 @@ isargnumeric(z)
 
 
 %% ===== Computation =====================================================
-out = sphbesselj(nu, z) + 1j .* sign .* sphbessely(nu, z);
+out = sphbesselj(nu, z) + 1i .* sign .* sphbessely(nu, z);

--- a/SFS_general/sphbesselh_zeros.m
+++ b/SFS_general/sphbesselh_zeros.m
@@ -142,7 +142,7 @@ function z0 = campos_zeros(n)
     y0 = polyval( [b3 b2 b1 b0],k);     % imaginary part
 
     % See Campos and Calderon (2011), Eq. (8)
-    z0 = x0 + 1j*y0;
+    z0 = x0 + 1i*y0;
 
 end
 

--- a/SFS_general/sphbesselh_zeros.m
+++ b/SFS_general/sphbesselh_zeros.m
@@ -1,16 +1,16 @@
 function [z,p] = sphbesselh_zeros(order)
-%SPHBESSELH_ZEROS finds zeros/roots of spherical hankel function
+%SPHBESSELH_ZEROS finds zeros/roots of spherical Hankel function
 %
 %   Usage: [z,p] = sphbesselh_zeros(order)
 %
 %   Input parameters:
-%       order   - order of hankel function
+%       order   - order of Hankel function
 %
 %   Output parameters:
 %       z       - zeros/roots fo the Bessel function
 %       p       - roots of the Bessel function
 %
-%   SPHBESSELH_ZEROS(order) finds zeros and poles for a spherical hankel 
+%   SPHBESSELH_ZEROS(order) finds zeros and poles for a spherical Hankel 
 %   function of the specified order. It is based on the investigations in 
 %   Hahn and Spors (2017) and the Python implementation in from scipy in
 %   signal.filter_design._bessel_zeros.

--- a/SFS_monochromatic/circexp_mono/circexp_mono_ps.m
+++ b/SFS_monochromatic/circexp_mono/circexp_mono_ps.m
@@ -72,6 +72,6 @@ k = 2*pi*f/c;
 Pm = zeros(1,2*Nce+1);
 for m=-Nce:Nce
   Pm(m+Nce+1) = ...
-      -1j*k*sphbesselh(abs(m),2,k*rs).*1i.^(abs(m)-m).*exp(-1i*m*phis);
+      -1i*k*sphbesselh(abs(m),2,k*rs).*1i.^(abs(m)-m).*exp(-1i*m*phis);
 end
 Pm = Pm./(4*pi);

--- a/SFS_monochromatic/circexp_mono/circexp_mono_ps.m
+++ b/SFS_monochromatic/circexp_mono/circexp_mono_ps.m
@@ -69,8 +69,9 @@ c = conf.c;
 %% ===== Computation =====================================================
 xs = xs - xq;  % shift coordinates
 [phis, rs] = cart2pol(xs(1),xs(2));
-omega = 2*pi*f;
 tau = rs/c;
+omega = 2*pi*f;
+omega_vec = [-omega.^2; 1i*omega; 1];  % vector for evaluation of SOS
 
 %-------------------------------------------------------------------------------
 % Implementation of
@@ -120,9 +121,7 @@ for m=0:Nce  % Negative m can be inferred from symmetry relations
     % Generate second-order-sections
     [sos, g] = zp2sos([zlr_comp; zh], [ph_comp; plr], klr*kh, 'down', 'none');
     % Compute value of sos at s = iw
-    Hm = g.* prod( (sos(:,1:3)*[-omega.^2; 1i*omega; 1]) ...
-        ./ (sos(:,4:6)*[-omega.^2; 1i*omega; 1]),1);
-    Pm(m+Nce+1) = Hm;
+    Pm(m+Nce+1) = g.*prod( (sos(:,1:3)*omega_vec)./(sos(:,4:6)*omega_vec),1);
 end
 
 Pm(1:Nce) = Pm(2*Nce+1:-1:Nce+2);  % symmetry

--- a/SFS_monochromatic/circexp_mono/circexp_mono_pw.m
+++ b/SFS_monochromatic/circexp_mono/circexp_mono_pw.m
@@ -66,5 +66,5 @@ c = conf.c;
 [phipw, ~] = cart2pol(npw(1),npw(2));
 
 m = (-Nce:Nce);
-Pm = (-1j).^m.*exp(-1j.*m.*phipw);
-Pm = Pm.*exp(-1j*xq*npw.'*2*pi*f./c);
+Pm = (-1i).^m.*exp(-1i.*m.*phipw);
+Pm = Pm.*exp(-1i*xq*npw.'*2*pi*f./c);

--- a/SFS_monochromatic/driving_function_mono_localwfs_sbl.m
+++ b/SFS_monochromatic/driving_function_mono_localwfs_sbl.m
@@ -15,7 +15,7 @@ function D = driving_function_mono_localwfs_sbl(x0,xs,src,f,conf)
 %       conf        - configuration struct (see SFS_config)
 %
 %   Output parameters:
-%       D           - driving signals [mxn]
+%       D           - driving function [nx1]
 %
 %   See also: sound_field_mono, sound_field_mono_localwfs_sbl
 
@@ -60,37 +60,13 @@ isargpositivescalar(f);
 isargstruct(conf);
 
 
-%% ===== Configuration ========================================================
-xref = conf.xref;
-N0 = size(x0,1);
-% Resolution of plane wave decomposition
-if isempty(conf.localwfs_sbl.Npw)
-    Npw = 2*ceil(2*pi*0.9*f/conf.c*conf.secondary_sources.size/2);
-else
-    Npw = conf.localwfs_sbl.Npw;
-end
-% Maximum order of circular basis expansion of sound field
-if isempty(conf.localwfs_sbl.order)
-    Nce = nfchoa_order(N0,conf);
-else
-    Nce = conf.localwfs_sbl.order;
-end
-
-
 %% ===== Computation ==========================================================
-% Circular expansion coefficients
 switch src
 case 'ps'
-    Pm = circexp_mono_ps(xs,Nce,f,xref,conf);
+    D = driving_function_mono_localwfs_sbl_ps(x0,xs,f,conf);
 case 'pw'
-    Pm = circexp_mono_pw(xs,Nce,f,xref,conf);
+    xs = xs./norm(xs);
+    D = driving_function_mono_localwfs_sbl_pw(x0,xs,f,conf);
 otherwise
     error('%s: %s is not a known source type.',upper(mfilename),src);
 end
-% Modal window
-wm = modal_weighting(Nce,conf);
-Pm = bsxfun(@times,[wm(end:-1:2),wm],Pm);
-% Plane wave decomposition
-Ppwd = pwd_mono_circexp(Pm,Npw);
-% Driving signal
-D = driving_function_mono_wfs_pwd(x0,Ppwd,f,xref,conf);

--- a/SFS_monochromatic/driving_function_mono_localwfs_vss.m
+++ b/SFS_monochromatic/driving_function_mono_localwfs_vss.m
@@ -113,4 +113,4 @@ end
 % Select secondary sources
 [x0,idx] = secondary_source_selection(x0,xv(:,1:6),'vss');
 % Driving functions for real source array
-D = driving_function_mono_wfs_vss(x0,xv,Dv,f,conf);
+D = driving_function_mono_wfs_vss(x0,xv,'fs',Dv,f,conf);

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_ps.m
@@ -1,19 +1,19 @@
-function [d,delay_offset] = driving_function_imp_localwfs_sbl_ps(x0,xs,conf)
-%DRIVING_FUNCTION_IMP_LOCALWFS_SBL_PS returns the driving signal for a point 
+function D = driving_function_mono_localwfs_sbl_ps(x0,xs,f,conf)
+%DRIVING_FUNCTION_MONO_LOCALWFS_SBL_PS returns the driving signal for a point 
 %source using local WFS with spatial bandwidth limitation
 %
-%   Usage: [d,delay_offset] = driving_function_imp_localwfs_sbl_ps(x0,xs,conf)
+%   Usage: D = driving_function_mono_localwfs_sbl_ps(x0,xs,f,conf)
 %
 %   Input parameters:
 %       x0          - position and direction of the secondary source / m [nx7]
 %       xs          - position of virtual point source / m [1x3]
+%       f           - frequency of the monochromatic source / Hz
 %       conf        - configuration struct (see SFS_config)
 %
 %   Output parameters:
-%       d               - driving signals [mxn]
-%       delay_offset    - additional added delay, so you can correct it
+%       D           - driving function [nx1]
 %
-%   See also: sound_field_imp_localwfs_sbl, driving_function_imp_localwfs_sbl
+%   See also: sound_field_mono_localwfs_sbl, driving_function_mono_localwfs_sbl
 %
 %   References:
 %       F. Winter, N. Hahn, and S. Spors (2017), "Time-Domain Realisation of 
@@ -51,16 +51,14 @@ function [d,delay_offset] = driving_function_imp_localwfs_sbl_ps(x0,xs,conf)
 
 
 %% ===== Checking of input  parameters ========================================
-nargmin = 3;
-nargmax = 3;
+nargmin = 4;
+nargmax = 4;
 narginchk(nargmin,nargmax);
 
 
 %% ===== Configuration ========================================================
 N0 = size(x0,1);
-Nfft = conf.N;
 xref = conf.xref;
-fs = conf.fs;
 % Ambisonics order
 if isempty(conf.localwfs_sbl.order)
     Nce = nfchoa_order(N0,conf);
@@ -75,14 +73,16 @@ else
 end
 % Resolution of plane wave decomposition
 if isempty(conf.localwfs_sbl.Npw)
-    Npw = 2*ceil(2*pi*0.9*fs/conf.c*conf.secondary_sources.size/2);
+    Npw = 2*ceil(2*pi*0.9*f/conf.c*conf.secondary_sources.size/2);
 else
     Npw = conf.localwfs_sbl.Npw;
 end
 
+
 %% ===== Variables ============================================================
-Nlr = ceil(Nce/2)*2;  % order of Linkwitz-Riley Coefficients
-Wlr = fc/fs*2;  % normalised cut-off frequency of Linkwitz-Riley
+Nlr = ceil(Nce/2)*2;  % order of Linkwitz-Riley Filter
+wc = 2*pi*fc;  % angular cutoff frequency of Linkwitz-Riley Filter
+omega = 2*pi*f;  % angular frequency
 
 
 %% ===== Computation ==========================================================
@@ -90,45 +90,37 @@ Wlr = fc/fs*2;  % normalised cut-off frequency of Linkwitz-Riley
 % === Local WFS for high frequencies ===
 % Regular circular expansion of point source (highpass implicitly)
 % Winter et al. (2017), eq. (14)
-[pm,delay_circexp] = circexp_imp_ps(xs,Nce,xref,fc,conf);
+Pm = circexp_mono_ps(xs,Nce,f,xref,fc,conf);
 % Modal window
 wm = modal_weighting(Nce,conf);
-pm = bsxfun(@times,wm,pm);
-% Plane wave decomposition, Winter et al. (2017), eq. (10)
-ppwd = pwd_imp_circexp(pm,Npw);
-% Driving signal, Winter et al. (2017), eq. (9)
-[dlwfs,delay_lwfs] = driving_function_imp_wfs_pwd(x0,ppwd,xref,conf);
+Pm = bsxfun(@times,[wm(end:-1:2),wm],Pm);
+% Plane wave decomposition, inverse FT of Winter et al. (2017), eq. (10)
+Ppwd = pwd_mono_circexp(Pm,Npw);
+% Driving signal, Winter et al. (2017), eq. (8)
+Dlwfs = driving_function_mono_wfs_pwd(x0,Ppwd,f,xref,conf);
 
 % === WFS for low frequencies ===
 % Secondary source selection
 [~,xdx] = secondary_source_selection(x0,xs,'ps');
 x0(xdx,:) = secondary_source_tapering(x0(xdx,:),conf);
-% Driving signal
-dwfs = zeros(Nfft,N0);
-[dwfs(:,xdx),~,~,delay_lp] = driving_function_imp_wfs(x0(xdx,:),xs,'ps',conf);
-% Coefficients for lowpass filtering of WFS driving function
-[zlp,plp,klp] = linkwitz_riley(Nlr,Wlr,'low');  % LR Lowpass filter
+% Driving function
+Dwfs = zeros(N0,1);
+Dwfs(xdx) = driving_function_mono_wfs(x0(xdx,:),xs,'ps',f,conf);
+% Coefficients for lowpass filtering of WFS Driving signal
+[zlp,plp,klp] = linkwitz_riley(Nlr,wc,'low','s');  % LR Lowpass filter
 % Lowpass filtering
 [sos,g] = zp2sos(zlp,plp,klp,'down','none');  % generate sos
-dwfs = sosfilt(sos,dwfs)*g;
-  
+Hlp = g.*prod( (sos(:,1:3)*[-omega.^2; 1i*omega; 1]) ...
+      ./ (sos(:,4:6)*[-omega.^2; 1i*omega; 1]),1);
+Dwfs = Dwfs.*Hlp;
+
 % === Crossover ===
-% Winter et al. (2017), eq. (15)
-% Get delay of delayline
-[~,delay_delayline] = delayline(1,0,0,conf);
-% Delay to compensate between lf-part and hf-part
-delay_comp = delay_lp - (delay_lwfs+delay_circexp+delay_delayline);
-% Combined driving signal
-d = dwfs + delayline(dlwfs,delay_comp,1,conf);
+D = Dlwfs + Dwfs;  % Winter et al. (2017), eq. (15)
 
 % === Compensate Phase-Distortions by Inverse Allpass ===
 % Winter et al. (2017), eq. (17)
-% TODO: ensure that the time-reserved filter is not truncated
-[zap,pap,kap] = linkwitz_riley(Nlr,Wlr,'all');  % LR Allpass filter
-[sos,g] = zp2sos(zap,pap,kap,'down','none');  % generate sos
-% (time-reversed) allpass filtering
-d = sosfilt(sos,d(end:-1:1,:))*g;
-d = d(end:-1:1,:);
-
-% Final delay
-delay_offset = delay_lp;
+[zap,pap,kap] = linkwitz_riley(Nlr,wc,'all','s');  % LR Allpass filter
+[sos,g] = zp2sos(pap,zap,kap,'down','none');  % SOS of inverse of Allpass
+Hap = g.*prod( (sos(:,1:3)*[-omega.^2; 1i*omega; 1]) ...
+      ./ (sos(:,4:6)*[-omega.^2; 1i*omega; 1]),1);
+D = D./Hap;

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_vss.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_vss.m
@@ -85,11 +85,11 @@ case 'fs'
         conf.driving_functions = 'default';
     elseif strcmp('2D',dimension)
         % === Focussed Line Sink ===
-        % We have to use the driving function setting directly, because in opposite
-        % to the case of a non-focused source where 'ps' and 'ls' are available as
-        % source types, for a focused source only 'fs' is available.
-        % Have a look at driving_function_mono_wfs_fs() for details on the
-        % implemented focused source types.
+        % We have to use the driving function setting directly, because in 
+        % opposite to the case of a non-focused source where 'ps' and 'ls' are
+        % available as source types, for a focused source only 'fs' is 
+        % available. Have a look at driving_function_mono_wfs_fs() for details
+        % on the implemented focused source types.
         conf.driving_functions = 'line_sink';
     else
         error('%s: %s is not a known source type.',upper(mfilename),dimension);
@@ -104,6 +104,8 @@ Nv = size(xv,1);
 N0 = size(x0,1);
 Dmatrix = zeros(N0,Nv);
 
+% it's ok to have zero secondary sources selected for pwd
+warning('off','SFS:x0'); 
 for idx=1:Nv
     [x0s, xdx] = ssd_select(x0,xv(idx,:));
     if (~isempty(x0s))
@@ -114,5 +116,6 @@ for idx=1:Nv
         Dmatrix(xdx,idx) = driv(x0s,xs) .* wtap;
     end
 end
+warning('on','SFS:x0');
 
 D = Dmatrix*(Dv(:).*xv(:,7));

--- a/SFS_monochromatic/pwd_mono/pwd_mono_circexp.m
+++ b/SFS_monochromatic/pwd_mono/pwd_mono_circexp.m
@@ -67,4 +67,4 @@ end
 %
 % phipw = n * 2*pi/Npw
 
-Ppwd = inverse_cht(bsxfun(@times,Pm,1j.^(-M:M)),Npw);
+Ppwd = inverse_cht(bsxfun(@times,Pm,1i.^(-M:M)),Npw);

--- a/SFS_monochromatic/pwd_mono/pwd_mono_circexp.m
+++ b/SFS_monochromatic/pwd_mono/pwd_mono_circexp.m
@@ -61,7 +61,7 @@ end
 % Implementation of
 %                 ___
 % _               \
-% P(phipw, w) =   /__     P (w) j^m  e^(+j m phipw)
+% P(phipw, w) =   /__     P (w) i^m  e^(+i m phipw)
 %               m=-M..M    m
 % with
 %

--- a/SFS_monochromatic/pwd_mono/pwd_mono_circexp.m
+++ b/SFS_monochromatic/pwd_mono/pwd_mono_circexp.m
@@ -1,23 +1,23 @@
-function [A,Phi] = inverse_cht(Am,Nphi)
-%INVERSE_CHT computes the inverse circular harmonics transform (ICHT)
+function Ppwd = pwd_mono_circexp(Pm,Npw)
+%PWD_MONO_CIRCEXP converts a circular basis expansion of a sound field to its
+%two-dimensional plane wave decomposition
 %
-%   Usage: [A,Phi] = inverse_cht(Am,[Nphi])
+%   Usage: Ppwd = pwd_mono_circexp(Pm,[Npw])
 %
 %   Input parameters:
-%       Am      - circular harmonics coefficients [N x (2*M+1)]
-%       Nphi    - number of equi-angular distributed angles, for which the ICHT
-%                 is computed, optional, default: 2*M+1
+%       Pm      - circular basis expansion [N x (2*M+1)]
+%       Npw     - number of equi-angular distributed plane waves, optional, 
+%                 default: 2*M+1
 %
 %   Output parameters:
-%       A       - inverse circular harmonics transform [N x Nphi]
-%       Phi     - corresponding angle of the ICHT [1 x Nphi]
+%       Ppwd    - plane wave decomposition [N x Npw]
 %
-%   See also: pwd_imp_circexp
+%   See also: driving_function_mono_localwfs_sbl
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *
 %                                                                            *
-% Copyright (c) 2010-2016 SFS Toolbox Developers                             *
+% Copyright (c) 2010-2017 SFS Toolbox Developers                             *
 %                                                                            *
 % Permission is hereby granted,  free of charge,  to any person  obtaining a *
 % copy of this software and associated documentation files (the "Software"), *
@@ -44,38 +44,27 @@ function [A,Phi] = inverse_cht(Am,Nphi)
 %*****************************************************************************
 
 
-%% ===== Checking of input  parameters ==================================
+%% ===== Checking of input parameters ==================================
 nargmin = 1;
 nargmax = 2;
 narginchk(nargmin,nargmax);
-isargmatrix(Am);
+isargmatrix(Pm);
+M = (size(Pm,2)-1)./2;
 if nargin == nargmin
-    Nphi = size(Am, 2);
+  Npw = 2*M+1;
 else
-    isargpositivescalar(Nphi);
+  isargpositivescalar(Npw);
 end
 
 
-%% ===== Computation ==================================================
-M = (size(Am,2)-1)/2;
-N = size(Am,1);
-
+%% ===== Computation ====================================================
 % Implementation of
-%           ___
-%           \
-% A(phi) =  /__    A  e^(+j*m*n*2*pi/Nphi)
-%         m=-M..M   m
+%                 ___
+% _               \
+% P(phipw, w) =   /__     P (w) j^m  e^(+j m phipw)
+%               m=-M..M    m
+% with
+%
+% phipw = n * 2*pi/Npw
 
-% Spatial IFFT
-A = zeros(N, Nphi);
-% this handles cases where Nphi < M
-for l=1:N
-    A(l,:) = sum(buffer(Am(l,:),Nphi),2);
-end
-A = circshift(A,[0,-M]);  % m = 0, ..., M, ..., -M, ..., -1
-A = ifft(A,[],2) * Nphi;  % IFFT includes factor 1/Nphi
-
-% Axis corresponding to ICHT
-if nargout>1
-    Phi = 0:2*pi / Nphi:2*pi*(1-1/Nphi);
-end
+Ppwd = inverse_cht(bsxfun(@times,Pm,1j.^(-M:M)),Npw);

--- a/SFS_monochromatic/sound_field_mono_localwfs_vss.m
+++ b/SFS_monochromatic/sound_field_mono_localwfs_vss.m
@@ -10,8 +10,7 @@ function varargout = sound_field_mono_localwfs_vss(X,Y,Z,xs,src,f,conf)
 %       xs          - position of virtual source or direction of plane
 %                     wave / m [1x3]
 %       src         - source type of the virtual source
-%                         'pw' - plane wave (xs is the direction of the
-%                                plane wave in this case)
+%                         'pw' - plane wave
 %                         'ps' - point source
 %                         'fs' - focused source
 %       f           - monochromatic frequency / Hz

--- a/SFS_monochromatic/sound_field_mono_sdm_kx.m
+++ b/SFS_monochromatic/sound_field_mono_sdm_kx.m
@@ -133,7 +133,7 @@ Gkx = zeros(length(kx),length(y));
 %                 \ 1/(2pi) K0( \|kx^2-(w/c)^2 y )
 %
 [kk,yy] = meshgrid(kx(idxpr),abs(y-X0(2)));
-Gkx(idxpr,:) = -1j/4 .* besselh(0,2,sqrt( (omega/c)^2 - kk.^2 ).* yy).';
+Gkx(idxpr,:) = -1i/4 .* besselh(0,2,sqrt( (omega/c)^2 - kk.^2 ).* yy).';
 if(withev)
     [kk,yy] = meshgrid(kx(idxev),abs(y-X0(2)));
     Gkx(idxev,:) = 1/(2*pi) .* besselk(0,sqrt( kk.^2 - (omega/c)^2).* yy).';
@@ -164,9 +164,9 @@ P = zeros(length(y),length(x));
 for n=1:length(x)
     % The following loop can be done faster by using the line below with repmat
     %for m=1:length(y)
-    %    P(m,n) = sum ( Pkx(:,m) .* exp(-1j*kx*x(n))' )';
+    %    P(m,n) = sum ( Pkx(:,m) .* exp(-1i*kx*x(n))' )';
     %end
-    P(:,n) = sum ( Pkx .* repmat(exp(-1j*kx*x(n))',1,resolution),1 )';
+    P(:,n) = sum ( Pkx .* repmat(exp(-1i*kx*x(n))',1,resolution),1 )';
 end
 
 % return parameter

--- a/SFS_start.m
+++ b/SFS_start.m
@@ -70,6 +70,8 @@ if exist('addpath')
     addpath([basepath,'/SFS_ir']);
     addpath([basepath,'/SFS_monochromatic']);
     addpath([basepath,'/SFS_monochromatic/driving_functions_mono']);
+    addpath([basepath,'/SFS_monochromatic/circexp_mono']);
+    addpath([basepath,'/SFS_monochromatic/pwd_mono']);
     addpath([basepath,'/SFS_plotting']);
     addpath([basepath,'/SFS_plotting/colormaps']);
     addpath([basepath,'/SFS_ssr']);
@@ -91,6 +93,8 @@ else
     path(path,[basepath,'/SFS_ir']);
     path(path,[basepath,'/SFS_monochromatic']);
     path(path,[basepath,'/SFS_monochromatic/driving_functions_mono']);
+    path(path,[basepath,'/SFS_monochromatic/circexp_mono']);
+    path(path,[basepath,'/SFS_monochromatic/pwd_mono']);
     path(path,[basepath,'/SFS_plotting']);
     path(path,[basepath,'/SFS_plotting/colormaps']);
     path(path,[basepath,'/SFS_ssr']);

--- a/SFS_time_domain/circexp_imp/circexp_imp_ps.m
+++ b/SFS_time_domain/circexp_imp/circexp_imp_ps.m
@@ -122,7 +122,7 @@ for m=0:Nce
         end
     end   
     % === Apply Hankel + LR Filter to current mode ===
-    % Zeros remaining after compensating the poles of hankel function (ph)
+    % Zeros remaining after compensating the poles of Hankel function (ph)
     zlr_comp = ones(length(zlr)-length(ph),1);
     % Generate second-order-sections
     [sos, g] = zp2sos([zlr_comp; zh], plr, klr*kh, 'down', 'none');

--- a/SFS_time_domain/circexp_imp/circexp_imp_ps.m
+++ b/SFS_time_domain/circexp_imp/circexp_imp_ps.m
@@ -126,7 +126,7 @@ for m=0:Nce
     % generate second-order-sections
     [sos, g] = zp2sos([zlr_comp; zh], plr, klr*kh, 'down', 'none');
     % filtering
-    pm(:,m+1) = sosfilt(sos, pm(:,m+1)).*g.*(1j).^m.*exp(-1j*m*phis);
+    pm(:,m+1) = sosfilt(sos, pm(:,m+1)).*g.*(1i).^m.*exp(-1i*m*phis);
 end
 pm = pm./(4*pi*rs);
 

--- a/SFS_time_domain/circexp_imp/circexp_imp_pw.m
+++ b/SFS_time_domain/circexp_imp/circexp_imp_pw.m
@@ -69,7 +69,7 @@ c = conf.c;
 pulse = dirac_imp();
 % Compute impulse responses for each mode m
 m = (0:Nce);
-pm = (-1j).^m.*exp(-1j*phipw*m)*pulse;
+pm = (-1i).^m.*exp(-1i*phipw*m)*pulse;
 pm = [pm; zeros(N-size(pm,1),Nce+1)];
 
 delay_offset = -(xq*npw.')/c;

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_pw.m
@@ -14,6 +14,11 @@ function [d,delay_offset] = driving_function_imp_localwfs_sbl_pw(x0,nk,conf)
 %       delay_offset    - additional added delay, so you can correct it
 %
 %   See also: sound_field_imp_localwfs_sbl, driving_function_imp_localwfs_sbl
+%
+%   References:
+%       F. Winter, N. Hahn, and S. Spors (2017), "Time-Domain Realisation of 
+%       Model-Based Rendering for 2.5D Local Wave Field Synthesis Using Spatial
+%       Bandwidth-Limitation," 25th EUSIPCO
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *
@@ -55,7 +60,7 @@ narginchk(nargmin,nargmax);
 N0 = size(x0,1);
 xref = conf.xref; 
 fs = conf.fs;
-% maximum order of circular basis expansion of sound field
+% Maximum order of circular basis expansion of sound field
 if isempty(conf.localwfs_sbl.order)
     Nce = nfchoa_order(N0,conf);
 else
@@ -69,14 +74,14 @@ else
 end
 
 %% ===== Computation ==========================================================
-% circular expansion coefficients
+% Circular expansion coefficients, Winter et al. (2017), eq. (12)
 [pm,delay_circexp] = circexp_imp_pw(nk,Nce,xref,conf);
-% modal window
+% Modal window
 wm = modal_weighting(Nce,conf);
 pm = bsxfun(@times,wm,pm);
-% plane wave decomposition
-ppwd = pwd_imp_circexp(pm,Npw);
-% driving signal
+% Plane wave decomposition
+ppwd = pwd_imp_circexp(pm,Npw);  % Winter et al. (2017), eq. (10)
+% Driving signal, Winter et al. (2017), eq. (9)
 [d,delay_lwfs] = driving_function_imp_wfs_pwd(x0,ppwd,xref,conf);
-% delay
+% Delay
 delay_offset = delay_lwfs + delay_circexp;

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_fs.m
@@ -5,7 +5,7 @@ function [sos,g] = driving_function_imp_nfchoa_fs(N,R,r,conf)
 %   Usage: sos = driving_function_imp_nfchoa_fs(N,R,r,conf)
 %
 %   Input parameters:
-%       N       - order of spherical hankel function
+%       N       - order of spherical Hankel function
 %       R       - radius of secondary source array / m
 %       r       - distance of focused source from array center / m
 %       conf    - configuration struct (see SFS_config)
@@ -65,7 +65,7 @@ driving_functions = conf.driving_functions;
 
 
 %% ===== Computation =====================================================
-% Find spherical hankel function zeros
+% Find spherical Hankel function zeros
 z = sphbesselh_zeros(N);
 
 % Get the delay and weighting factors

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ls.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ls.m
@@ -5,7 +5,7 @@ function [sos,g] = driving_function_imp_nfchoa_ls(N,R,r,conf)
 %   Usage: sos = driving_function_imp_nfchoa_ls(N,R,r,conf)
 %
 %   Input parameters:
-%       N       - order of spherical hankel function
+%       N       - order of spherical Hankel function
 %       R       - radius of secondary source array / m
 %       r       - distance of line source from array center / m
 %       conf    - configuration struct (see SFS_config)
@@ -65,7 +65,7 @@ driving_functions = conf.driving_functions;
 
 
 %% ===== Computation =====================================================
-% Find spherical hankel function zeros
+% Find spherical Hankel function zeros
 z = sphbesselh_zeros(N);
 
 % Get the delay and weighting factors

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
@@ -5,7 +5,7 @@ function [sos,g] = driving_function_imp_nfchoa_ps(N,R,r,conf)
 %   Usage: sos = driving_function_imp_nfchoa_ps(N,R,r,conf)
 %
 %   Input parameters:
-%       N       - order of spherical hankel function
+%       N       - order of spherical Hankel function
 %       R       - radius of secondary source array / m
 %       r       - distance of point source from array center / m
 %       conf    - configuration struct (see SFS_config)
@@ -70,7 +70,7 @@ driving_functions = conf.driving_functions;
 
 
 %% ===== Computation =====================================================
-% Find spherical hankel function zeros
+% Find spherical Hankel function zeros
 z = sphbesselh_zeros(N);
 
 % Get the delay and weighting factors

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
@@ -5,7 +5,7 @@ function [sos,g] = driving_function_imp_nfchoa_pw(N,R,conf)
 %   Usage: sos = driving_function_imp_nfchoa_pw(N,R,conf)
 %
 %   Input parameters:
-%       N       - order of spherical hankel function
+%       N       - order of spherical Hankel function
 %       R       - radius of secondary source array / m
 %       conf    - configuration struct (see SFS_config)
 %
@@ -69,7 +69,7 @@ driving_functions = conf.driving_functions;
 
 
 %% ===== Computation =====================================================
-% Find spherical hankel function zeros
+% Find spherical Hankel function zeros
 [z,p] = sphbesselh_zeros(N);
 
 % Get the delay and weighting factors

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_vss.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_vss.m
@@ -95,6 +95,8 @@ case 'pw'
     driv = @(X0,XS) driving_function_imp_wfs_pw(X0(:,1:3),X0(:,4:6),XS,conf);
 end
 
+% it's ok to have zero secondary sources selected for pwd
+warning('off','SFS:x0'); 
 idx = 1;
 for xvi = xv'
     % Select active source for single virtual secondary source
@@ -112,6 +114,7 @@ for xvi = xv'
     end
     idx = idx + 1;
 end
+warning('on','SFS:x0');
 
 % Remove delay offset, in order to begin always at t=0 with the first wave 
 % front at any secondary source

--- a/SFS_time_domain/pwd_imp/pwd_imp_circexp.m
+++ b/SFS_time_domain/pwd_imp/pwd_imp_circexp.m
@@ -69,4 +69,4 @@ end
 % phipw = n * 2*pi/Npw
 
 pm = [conj(pm(:,end:-1:2)), pm];  % append coefficients for negative m
-ppwd = inverse_cht(bsxfun(@times,pm,1j.^(-M:M)),Npw);
+ppwd = inverse_cht(bsxfun(@times,pm,1i.^(-M:M)),Npw);

--- a/SFS_time_domain/pwd_imp/pwd_imp_circexp.m
+++ b/SFS_time_domain/pwd_imp/pwd_imp_circexp.m
@@ -62,7 +62,7 @@ end
 % Implementation of
 %                 ___
 % _               \
-% p(phipw, t) =   /__     p (t) j^m  e^(-j m phipw)
+% p(phipw, t) =   /__     p (t) i^m  e^(-i m phipw)
 %               m=-M..M    m
 % with
 %

--- a/validation/test_exp_mono.m
+++ b/validation/test_exp_mono.m
@@ -1,0 +1,145 @@
+function status = test_exp_mono(modus)
+%TEST_EXP_MONO tests the different expansions of sound fields in frequency-domain
+%
+%   Usage: status = test_exp_mono(modus)
+%
+%   Input parameters:
+%       modus   - 0: numerical
+%                 1: visual
+%
+%   Output parameters:
+%       status  - true or false
+%
+%   TEST_EXP_MONO(modus) checks, if the circular basis expansions for plane
+%   waves and point sources are working. The circular basis expansions are
+%   converted to plane wave decompositions. Additionally, modal weighting
+%   functions are tested. Optionally, sound field plots of the plane wave
+%   decompositions are used for verification.
+
+%*****************************************************************************
+% The MIT License (MIT)                                                      *
+%                                                                            *
+% Copyright (c) 2010-2017 SFS Toolbox Developers                             *
+%                                                                            *
+% Permission is hereby granted,  free of charge,  to any person  obtaining a *
+% copy of this software and associated documentation files (the "Software"), *
+% to deal in the Software without  restriction, including without limitation *
+% the rights  to use, copy, modify, merge,  publish, distribute, sublicense, *
+% and/or  sell copies of  the Software,  and to permit  persons to whom  the *
+% Software is furnished to do so, subject to the following conditions:       *
+%                                                                            *
+% The above copyright notice and this permission notice shall be included in *
+% all copies or substantial portions of the Software.                        *
+%                                                                            *
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+% IMPLIED, INCLUDING BUT  NOT LIMITED TO THE  WARRANTIES OF MERCHANTABILITY, *
+% FITNESS  FOR A PARTICULAR  PURPOSE AND  NONINFRINGEMENT. IN NO EVENT SHALL *
+% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+% LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT, TORT  OR OTHERWISE, ARISING *
+% FROM,  OUT OF  OR IN  CONNECTION  WITH THE  SOFTWARE OR  THE USE  OR OTHER *
+% DEALINGS IN THE SOFTWARE.                                                  *
+%                                                                            *
+% The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
+% methods like wave field synthesis or higher order ambisonics.              *
+%                                                                            *
+% http://sfstoolbox.org                                 sfstoolbox@gmail.com *
+%*****************************************************************************
+
+
+status = false;
+
+
+%% ===== Checking of input  parameters ===================================
+nargmin = 1;
+nargmax = 1;
+narginchk(nargmin,nargmax);
+
+
+%% ===== Configuration ===================================================
+% Parameters
+conf = SFS_config;
+conf.plot.loudspeakers = false;  % do not plot loudspeakers
+conf.modal_window_parameter = 2.0;  % parameter for kaiser window
+
+c = conf.c;  % speed of sound
+
+% For sound field plots
+X = [-2, 2];
+Y = [-2, 2];
+Z = 0;
+
+f = 500;
+
+% Plane waves with equi-angular distribution
+Npw = 1024;
+phi0 = (0:Npw-1).'*2*pi/Npw;
+x0 = [cos(phi0) sin(phi0)];
+x0(:,3) = 0;
+x0(:,4:6) = x0(:,1:3);
+x0(:,7) = 1;
+
+% Test scenarios
+scenarios = { ...
+  'pw', [ 0.0 -1.0 0.0],  5, 'rect'   , [0.0 0.0 0.0]
+  'pw', [ 0.0 -1.0 0.0], 15, 'rect'   , [0.0 0.0 0.0]
+  'pw', [ 0.0 -1.0 0.0], 15, 'kaiser' , [0.0 0.0 0.0]
+  'pw', [ 0.0 -1.0 0.0],  5, 'rect'   , [0.5 1.0 0.0]
+  'pw', [ 0.0 -1.0 0.0], 15, 'rect'   , [0.5 1.0 0.0]
+  'pw', [ 0.0 -1.0 0.0], 15, 'kaiser' , [0.5 1.0 0.0]
+  'ps', [ 0.0  2.5 0.0],  5, 'rect'   , [0.0 0.0 0.0]
+  'ps', [ 0.0  2.5 0.0], 15, 'rect'   , [0.0 0.0 0.0]
+  'ps', [ 0.0  2.5 0.0], 15, 'kaiser' , [0.0 0.0 0.0]
+  'ps', [ 0.0  2.5 0.0],  5, 'rect'   , [0.5 1.0 0.0]
+  'ps', [ 0.0  2.5 0.0], 15, 'rect'   , [0.5 1.0 0.0]
+  'ps', [ 0.0  2.5 0.0], 15, 'kaiser' , [0.5 1.0 0.0]
+  };
+
+%% ===== Main ============================================================
+
+for ii=1:size(scenarios)
+
+    src = scenarios{ii,1};  % source type
+    xs = scenarios{ii,2};  % source position / direction of plane wave
+    Nce = scenarios{ii,3};  % modal order
+    conf.modal_window = scenarios{ii,4};  % type of modal weighting function
+    xq = scenarios{ii,5};  % expansion centre
+
+    % Circular expansion coefficients
+    switch src
+    case 'pw'
+        Pm = circexp_mono_pw(xs,Nce,f,xq,conf);
+        g = 1;
+    case 'ps'
+        Pm = circexp_mono_ps(xs,Nce,f,xq,conf);
+        g = 1./(4*pi*norm(xs-xq));
+    end
+
+    % Modal weighting of coefficients
+    wm = modal_weighting(Nce, conf);
+    Pm = bsxfun(@times, Pm, [wm(end:-1:2) wm]);
+
+    % Conversion to plane wave decomposition
+    Ppwd = pwd_mono_circexp(Pm, Npw);
+
+    if modus
+        % Sound field plot
+        P = sound_field_mono(X,Y,Z,x0,'pw',Ppwd,f,conf);      
+        plot_sound_field(P.*g,X,Y,Z,[],conf);
+        
+        % Title string
+        str = 'Plane wave decompostion of modally bandlimited';
+        switch src
+        case 'pw'
+            str = sprintf('%s plane wave', str);
+        case 'ps'
+            str = sprintf('%s point source', str);
+        end
+        str = sprintf(['%s ([%1.1f %1.1f %1.1f]):\n%s-window (M=%d), ' ...
+          'center of modal expansion at [%1.1f %1.1f %1.1f]'], ...
+          str, xs, conf.modal_window, Nce, xq);
+        title(str);
+    end
+end
+
+
+status = true;

--- a/validation/test_localwfs_sbl.m
+++ b/validation/test_localwfs_sbl.m
@@ -1,0 +1,183 @@
+function status = test_localwfs_sbl(modus)
+%TEST_LOCALWFS_SBL tests the LWFS-SBL driving functions
+%
+%   Usage: status = test_localwfs_sbl(modus)
+%
+%   Input parameters:
+%       modus   - 0: numerical
+%                 1: visual
+%
+%   Output parameters:
+%       status  - true or false
+%
+%   TEST_LOCALWFS_SBL(modus) checks if the monochromatic and time-domain 
+%   LWFS-SBL driving functions are working. Different sound fields are 
+%   calculated and plotted for visual inspection.
+
+%*****************************************************************************
+% The MIT License (MIT)                                                      *
+%                                                                            *
+% Copyright (c) 2010-2017 SFS Toolbox Developers                             *
+%                                                                            *
+% Permission is hereby granted,  free of charge,  to any person  obtaining a *
+% copy of this software and associated documentation files (the "Software"), *
+% to deal in the Software without  restriction, including without limitation *
+% the rights  to use, copy, modify, merge,  publish, distribute, sublicense, *
+% and/or  sell copies of  the Software,  and to permit  persons to whom  the *
+% Software is furnished to do so, subject to the following conditions:       *
+%                                                                            *
+% The above copyright notice and this permission notice shall be included in *
+% all copies or substantial portions of the Software.                        *
+%                                                                            *
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+% IMPLIED, INCLUDING BUT  NOT LIMITED TO THE  WARRANTIES OF MERCHANTABILITY, *
+% FITNESS  FOR A PARTICULAR  PURPOSE AND  NONINFRINGEMENT. IN NO EVENT SHALL *
+% THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+% LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT, TORT  OR OTHERWISE, ARISING *
+% FROM,  OUT OF  OR IN  CONNECTION  WITH THE  SOFTWARE OR  THE USE  OR OTHER *
+% DEALINGS IN THE SOFTWARE.                                                  *
+%                                                                            *
+% The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
+% methods like wave field synthesis or higher order ambisonics.              *
+%                                                                            *
+% http://sfstoolbox.org                                 sfstoolbox@gmail.com *
+%*****************************************************************************
+
+
+status = false;
+
+
+%% ===== Checking of input  parameters ===================================
+nargmin = 1;
+nargmax = 1;
+narginchk(nargmin,nargmax);
+
+
+%% ===== Configuration ===================================================
+% Parameters
+conf = SFS_config;
+
+conf.plot.useplot = modus;
+conf.plot.normalisation = 'center';
+conf.plot.loudspeakers = true;
+conf.plot.realloudspeakers = false;
+conf.resolution = 500;
+conf.t0 = 'source';
+
+% Default setting for WFS
+conf.usetapwin = true;
+conf.tapwinlen = 0.3;
+% Default settings for LWFS-SBL
+conf.localwfs_sbl.fc = 1200;
+conf.localwfs_sbl.Npw = 1024;
+
+% Range for sound field computation
+X = [-1 1];
+Y = [-1 1];
+Z = 0;
+
+f = 4000;
+
+conf.xref = [0,0,0];
+
+% Test scenarios
+scenarios = { ...
+    '2.5D', 'circular', 10, 'pw', [1 -1.0 0], 'mono'
+    '2.5D', 'circular', 20, 'pw', [1 -1.0 0], 'mono'
+    '2.5D', 'circular', 30, 'pw', [1 -1.0 0], 'mono'
+    '2.5D',   'linear', 10, 'pw', [1 -1.0 0], 'mono'
+    '2.5D',   'linear', 20, 'pw', [1 -1.0 0], 'mono'
+    '2.5D',   'linear', 30, 'pw', [1 -1.0 0], 'mono'
+    '2.5D',      'box', 10, 'pw', [1 -1.0 0], 'mono'
+    '2.5D',      'box', 20, 'pw', [1 -1.0 0], 'mono'
+    '2.5D',      'box', 30, 'pw', [1 -1.0 0], 'mono'
+    '2.5D', 'circular', 10, 'ps',  [1 2.5 0], 'mono'
+    '2.5D', 'circular', 20, 'ps',  [1 2.5 0], 'mono'
+    '2.5D', 'circular', 30, 'ps',  [1 2.5 0], 'mono'
+    '2.5D',   'linear', 10, 'ps',  [1 2.5 0], 'mono'
+    '2.5D',   'linear', 20, 'ps',  [1 2.5 0], 'mono'
+    '2.5D',   'linear', 30, 'ps',  [1 2.5 0], 'mono'
+    '2.5D',      'box', 10, 'ps',  [1 2.5 0], 'mono'
+    '2.5D',      'box', 20, 'ps',  [1 2.5 0], 'mono'
+    '2.5D',      'box', 30, 'ps',  [1 2.5 0], 'mono'
+    '2.5D', 'circular', 10, 'pw', [1 -1.0 0], 'imp'
+    '2.5D', 'circular', 20, 'pw', [1 -1.0 0], 'imp'
+    '2.5D', 'circular', 30, 'pw', [1 -1.0 0], 'imp'
+    '2.5D',   'linear', 10, 'pw', [1 -1.0 0], 'imp'
+    '2.5D',   'linear', 20, 'pw', [1 -1.0 0], 'imp'
+    '2.5D',   'linear', 30, 'pw', [1 -1.0 0], 'imp'
+    '2.5D',      'box', 10, 'pw', [1 -1.0 0], 'imp'
+    '2.5D',      'box', 20, 'pw', [1 -1.0 0], 'imp'
+    '2.5D',      'box', 30, 'pw', [1 -1.0 0], 'imp'
+    '2.5D', 'circular', 10, 'ps',  [1 2.5 0], 'imp'
+    '2.5D', 'circular', 20, 'ps',  [1 2.5 0], 'imp'
+    '2.5D', 'circular', 30, 'ps',  [1 2.5 0], 'imp'
+    '2.5D',   'linear', 10, 'ps',  [1 2.5 0], 'imp'
+    '2.5D',   'linear', 20, 'ps',  [1 2.5 0], 'imp'
+    '2.5D',   'linear', 30, 'ps',  [1 2.5 0], 'imp'
+    '2.5D',      'box', 10, 'ps',  [1 2.5 0], 'imp'
+    '2.5D',      'box', 20, 'ps',  [1 2.5 0], 'imp'
+    '2.5D',      'box', 30, 'ps',  [1 2.5 0], 'imp'
+    };
+
+% Start testing
+for ii=1:size(scenarios,1)
+    
+    conf.dimension = scenarios{ii,1};
+    
+    % Set loudspeaker array
+    switch scenarios{ii,2}
+    case 'linear'
+        conf.secondary_sources.geometry = 'linear';
+        conf.secondary_sources.number = 56;
+        conf.secondary_sources.size = 2;
+        conf.secondary_sources.center = [0 1 0];
+    case 'circular'
+        conf.secondary_sources.geometry = 'circular';
+        conf.secondary_sources.number = 56;
+        conf.secondary_sources.size = 2;
+        conf.secondary_sources.center = [0 0 0];
+    case 'box'
+        conf.secondary_sources.geometry = 'box';
+        conf.secondary_sources.number = 56*4;
+        conf.secondary_sources.size = 2;
+        conf.secondary_sources.center = [0 0 0];
+    end
+    
+    conf.localwfs_sbl.order = scenarios{ii,3};
+    
+    % Set desired sound field
+    src = scenarios{ii,4};
+    xs = scenarios{ii,5};
+    
+    % Set domain (monochromatic or time)
+    switch scenarios{ii,6}
+    case 'mono'
+        conf.plot.usedb = false;
+        [~] = sound_field_mono_localwfs_sbl(X,Y,Z,xs,src,f,conf);
+    case 'imp'
+        % Set t for time-shapshot
+        switch src
+        case {'ps', 'ls', 'fs'}
+            t = norm(xs - conf.xref)/conf.c;
+        case {'pw'}
+            t = 0;
+        otherwise
+            error('unknown source type');
+        end
+        conf.plot.usedb = true;
+        [~] = sound_field_imp_localwfs_sbl(X,Y,Z,xs,src,t,conf);
+    end
+    
+    progress_bar(ii,size(scenarios,1));
+
+    % Title of plot
+    if modus
+        title(sprintf(['LWFS-SBL (%s,%s): %s SSD, order: %d, %s' ...
+            ' (%02.02f, %02.02f, %02.02f)'], scenarios{ii,1}, scenarios{ii,6}...
+            , scenarios{ii,2}, scenarios{ii,3}, src, xs));
+    end
+end
+
+
+status = true;

--- a/validation/test_sphbesselh_zeros.m
+++ b/validation/test_sphbesselh_zeros.m
@@ -12,7 +12,7 @@ function status = test_sphbesselh_zeros(modus)
 %       status  - true or false
 %
 %   TEST_SPHBESSELH_ZEROS(modus) creates plots showing the zeros of the
-%   spherical hankel function as calculated by sphbesselh_zeros(order).
+%   spherical Hankel function as calculated by sphbesselh_zeros(order).
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *


### PR DESCRIPTION
* circular basis expansion of monochromatic plane wave and point source
* extension of ``driving_function_mono_wfs_vss`` to handle plane wave and focused source as virtual secondary sources (similar to time domain implementation)
* add ``driving_function_mono_wfs_pwd`` to handle plane wave decompositions
* add ``pwd_mono_circexp`` to convert circular basis expansion into plae wave decomposition