### PR TITLE
Simplify help messages

### DIFF
--- a/SFS_analysis/freq_response_line_source.m
+++ b/SFS_analysis/freq_response_line_source.m
@@ -1,6 +1,5 @@
 function varargout = freq_response_line_source(X,xs,conf)
-%FREQ_RESPONSE_WFS simulates the frequency response for a line source at the
-%given listener position
+%FREQ_RESPONSE_LINE_SOURCE frequency response of a line source
 %
 %   Usage: [S,f] = freq_response_line_source(X,xs,conf)
 %

--- a/SFS_analysis/freq_response_localwfs_sbl.m
+++ b/SFS_analysis/freq_response_localwfs_sbl.m
@@ -1,6 +1,5 @@
 function varargout = freq_response_localwfs_sbl(X,xs,src,conf)
-%FREQ_RESPONSE_LOCALWFS_SBL simulates the frequency response for WFS at the given
-%listener position
+%FREQ_RESPONSE_LOCALWFS_SBL frequency response for local WFS
 %
 %   Usage: [S,f] = freq_response_loaclwfs_sbl(X,xs,src,conf)
 %

--- a/SFS_analysis/freq_response_localwfs_vss.m
+++ b/SFS_analysis/freq_response_localwfs_vss.m
@@ -1,6 +1,5 @@
 function varargout = freq_response_localwfs_vss(X,xs,src,conf)
-%FREQ_RESPONSE_LOCALWFS_VSS simulates the frequency response for local WFS at
-%the given listener position
+%FREQ_RESPONSE_LOCALWFS_VSS frequency response for local WFS
 %
 %   Usage: [S,f] = freq_response_localwfs_vss(X,xs,src,conf)
 %

--- a/SFS_analysis/freq_response_nfchoa.m
+++ b/SFS_analysis/freq_response_nfchoa.m
@@ -1,6 +1,5 @@
 function varargout = freq_response_nfchoa(X,xs,src,conf)
-%FREQ_RESPONSE_NFCHOA simulates the frequency response for NFC-HOA at the given
-%listener position
+%FREQ_RESPONSE_NFCHOA frequency response for NFC-HOA
 %
 %   Usage: [S,f] = freq_response_nfchoa(X,xs,src,conf)
 %

--- a/SFS_analysis/freq_response_point_source.m
+++ b/SFS_analysis/freq_response_point_source.m
@@ -1,6 +1,5 @@
 function varargout = freq_response_point_source(X,xs,conf)
-%FREQ_RESPONSE_WFS simulates the frequency response for a point source at the
-%given listener position
+%FREQ_RESPONSE_POINT_SOURCE frequency response of a point
 %
 %   Usage: [S,f] = freq_response_point_source(X,xs,conf)
 %

--- a/SFS_analysis/freq_response_wfs.m
+++ b/SFS_analysis/freq_response_wfs.m
@@ -1,6 +1,5 @@
 function varargout = freq_response_wfs(X,xs,src,conf)
-%FREQ_RESPONSE_WFS simulates the frequency response for WFS at the given
-%listener position
+%FREQ_RESPONSE_WFS frequency response for WFS
 %
 %   Usage: [S,f] = freq_response_wfs(X,xs,src,conf)
 %

--- a/SFS_analysis/time_response_line_source.m
+++ b/SFS_analysis/time_response_line_source.m
@@ -1,6 +1,5 @@
 function varargout = time_response_line_source(X,xs,conf)
-%TIME_RESPONSE_LINE_SOURCE simulates the time response for a line source at
-%the given listener position
+%TIME_RESPONSE_LINE_SOURCE time response of a line source
 %
 %   Usage: [s,t] = time_response_line_source(X,xs,conf)
 %

--- a/SFS_analysis/time_response_localwfs_sbl.m
+++ b/SFS_analysis/time_response_localwfs_sbl.m
@@ -1,6 +1,5 @@
 function varargout = time_response_localwfs_sbl(X,xs,src,conf)
-%TIME_RESPONSE_LOCALWFS_SBL simulates the time response for LOCAL WFS at the
-%given listener position
+%TIME_RESPONSE_LOCALWFS_SBL time response for local WFS
 %
 %   Usage: [s,t] = time_response_localwfs_sbl(X,xs,src,conf)
 %

--- a/SFS_analysis/time_response_localwfs_vss.m
+++ b/SFS_analysis/time_response_localwfs_vss.m
@@ -1,6 +1,5 @@
 function varargout = time_response_localwfs_vss(X,xs,src,conf)
-%TIME_RESPONSE_LOCALWFS_VSS simulates the time response for LOCAL WFS at the
-%given listener position
+%TIME_RESPONSE_LOCALWFS_VSS time response for local WFS
 %
 %   Usage: [s,t] = time_response_localwfs_vss(X,xs,src,conf)
 %

--- a/SFS_analysis/time_response_nfchoa.m
+++ b/SFS_analysis/time_response_nfchoa.m
@@ -1,6 +1,5 @@
 function varargout = time_response_nfchoa(X,xs,src,conf)
-%TIME_RESPONSE_NFCHOA simulates the time response for NFC-HOA at the given
-%listener position
+%TIME_RESPONSE_NFCHOA time response for NFC-HOA
 %
 %   Usage: [s,t] = time_response_nfchoa(X,xs,src,conf)
 %

--- a/SFS_analysis/time_response_point_source.m
+++ b/SFS_analysis/time_response_point_source.m
@@ -1,6 +1,5 @@
 function varargout = time_response_point_source(X,xs,conf)
-%TIME_RESPONSE_POINT_SOURCE simulates the time response for a point source at
-%the given listener position
+%TIME_RESPONSE_POINT_SOURCE time response of a point source
 %
 %   Usage: [s,t] = time_response_point_source(X,xs,conf)
 %

--- a/SFS_analysis/time_response_wfs.m
+++ b/SFS_analysis/time_response_wfs.m
@@ -1,6 +1,5 @@
 function varargout = time_response_wfs(X,xs,src,conf)
-%TIME_RESPONSE_WFS simulates the time response for WFS at the given
-%listener position
+%TIME_RESPONSE_WFS time response for WFS
 %
 %   Usage: [s,t] = time_response_wfs(X,xs,src,conf)
 %

--- a/SFS_analysis/wave_fronts_wfs.m
+++ b/SFS_analysis/wave_fronts_wfs.m
@@ -1,6 +1,5 @@
 function varargout = wave_fronts_wfs(X,phi,xs,src,gnuplot,conf)
-%WAVE_FRONTS_WFS returns direction, amplitude and time of the single wave
-%   fronts for WFS
+%WAVE_FRONTS_WFS direction, amplitude and time of WFS wave fronts
 %
 %   Usage: [alpha,a,t] = wave_fronts_wfs(X,phi,xs,src,[gnuplot],conf)
 %

--- a/SFS_binaural_synthesis/compensate_headphone.m
+++ b/SFS_binaural_synthesis/compensate_headphone.m
@@ -1,5 +1,5 @@
 function ir = compensate_headphone(ir,conf)
-%COMPENSATE_HEADPHONE applies a headphone compensation to the IR
+%COMPENSATE_HEADPHONE applies a headphone compensation to an impulse response
 %
 %   Usage: ir = compensate_headphone(ir,conf)
 %

--- a/SFS_binaural_synthesis/ir_generic.m
+++ b/SFS_binaural_synthesis/ir_generic.m
@@ -1,6 +1,5 @@
 function ir = ir_generic(X,head_orientation,x0,d,sofa,conf)
-%IR_GENERIC generates driving signals including the impulse responses from the
-%secondary sources to the listener position
+%IR_GENERIC impulse response of secondary sources including driving signals
 %
 %   Usage: ir = ir_generic(X,head_orientation,x0,d,sofa,conf)
 %
@@ -18,7 +17,9 @@ function ir = ir_generic(X,head_orientation,x0,d,sofa,conf)
 %                          (nx2 matrix)
 %
 %   IR_GENERIC(X,head_orientation,x0,d,sofa,conf) calculates a binaural room
-%   impulse response for the given secondary sources and driving signals.
+%   impulse response using the provided sofa database for the sound travelling
+%   from the secondary sources to the listener position. In addition, the given
+%   driving signals d are incorporated.
 %
 %   See also: ir_wfs, ir_nfchoa, ir_point_source, auralize_ir
 

--- a/SFS_binaural_synthesis/ir_localwfs.m
+++ b/SFS_binaural_synthesis/ir_localwfs.m
@@ -1,5 +1,5 @@
 function [ir,x0] = ir_localwfs(X,head_orientation,xs,src,sofa,conf)
-%IR_LOCALWFS generates a binaural simulation of local WFS
+%IR_LOCALWFS binaural simulation of local WFS
 %
 %   Usage: [ir,x0] = ir_localwfs(X,head_orientation,xs,src,sofa,conf)
 %
@@ -19,7 +19,7 @@ function [ir,x0] = ir_localwfs(X,head_orientation,xs,src,sofa,conf)
 %       x0               - secondary sources / m
 %
 %   IR_LOCALWFS(X,head_orientation,xs,src,sofa,conf) calculates a binaural room
-%   impulse response for a virtual source at xs for a virtual LOCAL WFS array
+%   impulse response for a virtual source at xs for a virtual local WFS array
 %   and a listener located at X.
 %
 %   See also: ssr_brs_wfs, ir_point_source, auralize_ir

--- a/SFS_binaural_synthesis/ir_nfchoa.m
+++ b/SFS_binaural_synthesis/ir_nfchoa.m
@@ -1,5 +1,5 @@
 function [ir,x0,delay] = ir_nfchoa(X,head_orientation,xs,src,sofa,conf)
-%IR_NFCHOA generates a binaural simulation of NFCHOA
+%IR_NFCHOA binaural simulation of NFCHOA
 %
 %   Usage: [ir,x0,delay] = ir_nfchoa(X,head_orientation,xs,src,sofa,conf)
 %

--- a/SFS_binaural_synthesis/ir_point_source.m
+++ b/SFS_binaural_synthesis/ir_point_source.m
@@ -1,5 +1,5 @@
 function ir = ir_point_source(X,head_orientation,xs,sofa,conf)
-%IR_POINT_SOURCE generates a binaural simulation of a point source
+%IR_POINT_SOURCE binaural simulation of a point source
 %
 %   Usage: ir = ir_point_source(X,head_orientation,xs,sofa,conf)
 %

--- a/SFS_binaural_synthesis/ir_wfs.m
+++ b/SFS_binaural_synthesis/ir_wfs.m
@@ -1,5 +1,5 @@
 function [ir,x0,delay] = ir_wfs(X,head_orientation,xs,src,sofa,conf)
-%IR_WFS generates a binaural simulation of WFS
+%IR_WFS binaural simulation of WFS
 %
 %   Usage: [ir,x0,delay] = ir_wfs(X,head_orientation,xs,src,sofa,conf)
 %

--- a/SFS_general/aliasing_frequency.m
+++ b/SFS_general/aliasing_frequency.m
@@ -1,14 +1,13 @@
 function [fal,dx0] = aliasing_frequency(x0,conf)
-%ALIASING_FREQUENCY returns the aliasing frequency for the given secondary
-%sources
+%ALIASING_FREQUENCY aliasing frequency for the given secondary sources
 %
 %   Usage: [fal,dx0] = aliasing_frequency([x0],conf)
 %
-%   Input options:
+%   Input parameters:
 %       x0      - secondary sources / m
 %       conf    - configuration struct (see SFS_config)
 %
-%   Output options:
+%   Output parameters:
 %       fal     - aliasing frequency / Hz
 %       dx0     - mean distance between secondary sources / m
 %

--- a/SFS_general/asslegendre.m
+++ b/SFS_general/asslegendre.m
@@ -1,5 +1,5 @@
 function [ Lnm ] = asslegendre(n,m,arg)
-%ASSLEGENDRE calculates associates Legendre function of degree n and order m
+%ASSLEGENDRE associates Legendre function of degree n and order m
 %
 %   Usage: Lnm = asslegendre(n,m,arg)
 %
@@ -10,9 +10,6 @@ function [ Lnm ] = asslegendre(n,m,arg)
 %
 %   Output parameters:
 %       Lnm   - associates Legendre function
-%
-%   ASSLEGENDRE(n,m,arg) calculates the associates Legendre function of degree
-%   n and order m for the values arg.
 %
 %   See also: sphharmonics, legendre
 

--- a/SFS_general/bandpass.m
+++ b/SFS_general/bandpass.m
@@ -1,5 +1,5 @@
 function sig =  bandpass(sig,flow,fhigh,conf)
-%BANDPASS filters a signal by a bandpass
+%BANDPASS applies a bandpass to a signal
 %
 %   Usage: sig = bandpass(sig,flow,fhigh,conf)
 %
@@ -11,9 +11,6 @@ function sig =  bandpass(sig,flow,fhigh,conf)
 %
 %   Output parameters:
 %       sig    - filtered signal
-%
-%   BANDPASS(sig,flow,fhigh,conf) filters the given signal with a bandpass
-%   filter with cutoff frequencies of flow and fhigh.
 %
 %   See also: sound_field_imp_wfs
 

--- a/SFS_general/bilinear_transform.m
+++ b/SFS_general/bilinear_transform.m
@@ -1,5 +1,5 @@
 function [b,a] = bilinear_transform(sos,conf)
-%BILINEAR_TRANSFORM returns the second-order section as filter coefficients
+%BILINEAR_TRANSFORM second-order section as filter coefficients
 %
 %   Usage: [b,a] = bilinear_transform(sos,conf)
 %

--- a/SFS_general/cm2in.m
+++ b/SFS_general/cm2in.m
@@ -3,13 +3,11 @@ function y = cm2in(x)
 %
 %   Usage: y = cm2in(x)
 %
-%   Input options:
+%   Input parameters:
 %       x     - input / cm
 %
-%   Output options:
+%   Output parameters:
 %       y     - output / inches
-%
-%   CM2IN(x) returns the given value x in inches.
 %
 %   See also: cm2px, px2in, px2cm, in2cm, in2px
 

--- a/SFS_general/cm2px.m
+++ b/SFS_general/cm2px.m
@@ -3,13 +3,11 @@ function y = cm2px(x)
 %
 %   Usage: y = cm2px(x)
 %
-%   Input options:
+%   Input parameters:
 %       x     - input / cm
 %
-%   Output options:
+%   Output parameters:
 %       y     - output / px
-%
-%   CM2PX(x) returns the given value x in pixels.
 %
 %   See also: cm2in, px2in, px2cm, in2cm, in2px
 

--- a/SFS_general/column_vector.m
+++ b/SFS_general/column_vector.m
@@ -1,5 +1,5 @@
 function varargout = column_vector(varargin)
-%COLUMN_VECTOR makes a column vector from the given vector
+%COLUMN_VECTOR returns the given vectors as column vectors
 %
 %   Usage: [x1,x2,...] = column_vector(x1,x2,...)
 %
@@ -8,9 +8,6 @@ function varargout = column_vector(varargin)
 %
 %   Output parameters:
 %       x1,x2,...  - input vectors as column vectors
-%
-%   COLUMN_VECTOR(x1,x2,...) returns the given vectors x1,x2,... as column
-%   vectors.
 %
 %   See also: row_vector
 

--- a/SFS_general/correct_azimuth.m
+++ b/SFS_general/correct_azimuth.m
@@ -1,5 +1,5 @@
 function phi = correct_azimuth(phi)
-%CORRECT_AZIMUTH ensures correct values for azimuth angles
+%CORRECT_AZIMUTH ensures azimuth angle between -pi and +pi-eps 
 %
 %   Usage: phi = correct_azimuth(phi)
 %
@@ -8,9 +8,6 @@ function phi = correct_azimuth(phi)
 %
 %   Output paramteres:
 %       phi     - angle between -pi and +pi-eps / rad
-%
-%   CORRECT_AZIMUTH(phi) returns a value for azimuth phi between
-%   -pi and +pi-eps.
 %
 %   See also: correct_elevation, get_ir
 

--- a/SFS_general/correct_elevation.m
+++ b/SFS_general/correct_elevation.m
@@ -1,5 +1,5 @@
 function delta = correct_elevation(delta)
-%CORRECT_ELEVATION ensures correct values for elevation angles
+%CORRECT_ELEVATION ensures elevation angle between -pi/2 and pi/2
 %
 %   Usage: delta = correct_elevation(delta)
 %
@@ -8,9 +8,6 @@ function delta = correct_elevation(delta)
 %
 %   Output paramteres:
 %       delta     - angle between -pi/2 and +pi/2 / rad
-%
-%   CORRECT_ELEVATION(delta) returns a value for elevation delta between
-%   -pi/2 and pi/2.
 %
 %   See also: correct_azimuth, get_ir
 

--- a/SFS_general/deg.m
+++ b/SFS_general/deg.m
@@ -1,15 +1,13 @@
 function phi = deg(phi)
-%DEG returns the given angle in deg
+%DEG angle in deg
 %
 %   Usage: phi = deg(phi)
 %
-%   Input options:
+%   Input parameters:
 %       phi     - angle / rad, can be a scalar or matrix (rad)
 %
-%   Output options:
+%   Output parameters:
 %       phi     - angle / degree
-%
-%   DEG(phi) returns the given angles phi in degree.
 %
 %   See also: rad
 

--- a/SFS_general/delayline.m
+++ b/SFS_general/delayline.m
@@ -1,5 +1,5 @@
 function [sig,delay_offset] = delayline(sig,dt,weight,conf)
-%DELAYLINE implements a (fractional) delay line with weights
+%DELAYLINE (fractional) delay line with weights
 %
 %   Usage: [sig,delay_offset] = delayline(sig,dt,weight,conf)
 %

--- a/SFS_general/direction_vector.m
+++ b/SFS_general/direction_vector.m
@@ -1,5 +1,5 @@
 function directions = direction_vector(x1,x2)
-%DIRECTION_VECTOR return unit vector(s) pointing from x1 to x2
+%DIRECTION_VECTOR unit vector(s) pointing from x1 to x2
 %
 %   Usage: n = direction_vector(x1,x2)
 %
@@ -9,9 +9,6 @@ function directions = direction_vector(x1,x2)
 %
 %   Output parameters:
 %       n   - unit vector(s) pointing in the direction(s) from x1 to x2
-%
-%   DIRECTION_VECTOR(x1,x2) calculates the unit vectors pointing from
-%   n-dimensional points x1 to the n-dimensional points x2.
 %
 %   See also: secondary_source_positions
 

--- a/SFS_general/findcols.m
+++ b/SFS_general/findcols.m
@@ -1,5 +1,5 @@
 function k = findcols(A,b)
-%FINDCOLS finds indices of a given column within a matrix.
+%FINDCOLS finds a column within a matrix.
 %
 %   Usage: idx = findcols(A,b)
 %

--- a/SFS_general/findnearestneighbour.m
+++ b/SFS_general/findnearestneighbour.m
@@ -1,5 +1,5 @@
 function [idx,weights] = findnearestneighbour(A,b,N)
-%FINDNEARESTNEIGHBOUR finds the N nearest neighbours and weights (for N<=2)
+%FINDNEARESTNEIGHBOUR finds the N nearest neighbours
 %
 %   Usage: [idx,weights] = findnearestneighbour(A,b,N)
 %

--- a/SFS_general/findrows.m
+++ b/SFS_general/findrows.m
@@ -1,5 +1,5 @@
 function k = findrows(A,b)
-%FINDROWS finds indices of a given row within a matrix.
+%FINDROWS finds a row vector within a matrix.
 %
 %   Usage: idx = findrows(A,b)
 %

--- a/SFS_general/fix_length.m
+++ b/SFS_general/fix_length.m
@@ -1,5 +1,5 @@
 function sig = fix_length(sig,N)
-%FIX_LENGTH pads zeros or removes entries from the signal according to length N
+%FIX_LENGTH pads zeros or removes entries from signal accroding to length N
 %
 %   Usage: sig = fix_length(sig,N)
 %

--- a/SFS_general/gaindb.m
+++ b/SFS_general/gaindb.m
@@ -10,8 +10,6 @@ function inoutsig = gaindb(inoutsig,gn)
 %   Output parameters:
 %       inoutsig    - given signal with new level
 %
-%   GAINDB(insig,gn) changes the level of the signal by gn dB.
-%
 %   See also: rms, db, setleveldb
 
 %*****************************************************************************

--- a/SFS_general/get_shelve_lagrange.m
+++ b/SFS_general/get_shelve_lagrange.m
@@ -1,5 +1,5 @@
 function H = get_shelve_lagrange(f,H,FlagSub,fSub,FlagAliasing,fAliasing,Bandwidth_in_Oct)
-%GET_SHELVE_LAGRANGE does an Lagrange interpolation towards shelving filter
+%GET_SHELVE_LAGRANGE Lagrange interpolation towards shelving filter
 %
 %   Usage: H = get_shelve_lagrange(f,H,FlagSub,fSub,FlagAliasing, ...
 %                                  fAliasing,Bandwidth_in_Oct)

--- a/SFS_general/get_spherical_grid.m
+++ b/SFS_general/get_spherical_grid.m
@@ -1,5 +1,5 @@
 function [points,weights] = get_spherical_grid(number,conf)
-%GET_SPHERICAL_GRID returns grid points and weights
+%GET_SPHERICAL_GRID spherical grid points and weights
 %
 %   Usage: [points,weights] = get_spherical_grid(number,conf)
 %

--- a/SFS_general/hann_window.m
+++ b/SFS_general/hann_window.m
@@ -1,5 +1,5 @@
 function win = hann_window(onset,offset,nsamples)
-%HANN_WINDOW generates a Hann window with on and off ramp
+%HANN_WINDOW Hann window with on and off ramp
 %
 %   Usage: win = hann_window(onset,offset,nsamples)
 %

--- a/SFS_general/in2cm.m
+++ b/SFS_general/in2cm.m
@@ -3,13 +3,11 @@ function y = in2cm(x)
 %
 %   Usage: y = in2cm(x)
 %
-%   Input options:
+%   Input parameters:
 %       x     - input / inches
 %
-%   Output options:
+%   Output parameters:
 %       y     - output / cm
-%
-%   IN2CM(x) returns the given value x in centimeters.
 %
 %   See also: in2px, cm2px, cm2in, px2in, px2cm
 

--- a/SFS_general/in2px.m
+++ b/SFS_general/in2px.m
@@ -3,13 +3,11 @@ function y = in2px(x)
 %
 %   Usage: y = in2px(x)
 %
-%   Input options:
+%   Input parameters:
 %       x     - input / inches
 %
-%   Output options:
+%   Output parameters:
 %       y     - output / px
-%
-%   IN2PX(x) returns the given value x in pixel.
 %
 %   See also: in2cm, cm2px, cm2in, px2in, px2cm
 

--- a/SFS_general/inverse_cht.m
+++ b/SFS_general/inverse_cht.m
@@ -1,5 +1,5 @@
 function [A,Phi] = inverse_cht(Am,Nphi)
-%INVERSE_CHT computes the inverse circular harmonics transform (ICHT)
+%INVERSE_CHT inverse circular harmonics transform (ICHT)
 %
 %   Usage: [A,Phi] = inverse_cht(Am,[Nphi])
 %

--- a/SFS_general/inverse_lt.m
+++ b/SFS_general/inverse_lt.m
@@ -1,5 +1,5 @@
 function A = inverse_lt(Am,x)
-%INVERSE_LT computes the inverse Legendre transform (ILT)
+%INVERSE_LT inverse Legendre transform (ILT)
 %
 %   Usage: [A,mu] = inverse_lt(Am,Nx)
 %

--- a/SFS_general/is_dim_custom.m
+++ b/SFS_general/is_dim_custom.m
@@ -1,5 +1,5 @@
 function bool = is_dim_custom(varargin)
-%IS_DIM_CUSTOM returns true for a custom grid, otherwise false
+%IS_DIM_CUSTOM true for a custom grid
 %
 %   Usage: bool = is_grid_custom(x1,x2,...)
 %

--- a/SFS_general/is_dim_singleton.m
+++ b/SFS_general/is_dim_singleton.m
@@ -1,5 +1,5 @@
 function bool = is_dim_singleton(varargin)
-%IS_DIM_SINGLETON returns true for a singleton dimension
+%IS_DIM_SINGLETON true for a singleton axis dimension
 %
 %   Usage: bool = is_dim_singleton(x1,x2,...)
 %
@@ -9,9 +9,6 @@ function bool = is_dim_singleton(varargin)
 %   Output parameters:
 %       bool      - array of logical indicating whether each input is a
 %                   singleton dimension
-%
-%   IS_DIM_SINGLETON(x1,x2,..) checks if we have a singleton dimension for any
-%   of the given x,y,z values.
 %
 %   See also: is_dim_custom, xyz_axes_selection, plot_sound_field
 

--- a/SFS_general/iseven.m
+++ b/SFS_general/iseven.m
@@ -1,5 +1,5 @@
 function bool = iseven(number)
-%ISEVEN returns true for even integer
+%ISEVEN true for even integer
 %
 %   Usage: bool = iseven(number)
 %
@@ -8,8 +8,6 @@ function bool = iseven(number)
 %
 %   Output parameters:
 %       bool    - true if the number is even, false else
-%
-%   ISEVEN(number) checks if the given number is even.
 %
 %   See also: isodd
 

--- a/SFS_general/ismonoinc.m
+++ b/SFS_general/ismonoinc.m
@@ -1,5 +1,5 @@
 function bool = ismonoinc(x)
-%ISMONOINC checks if the data of x are monotonic increasing
+%ISMONOINC true for monotonic increasing data
 %
 %   Usage: bool = ismonoinc(x)
 %
@@ -8,8 +8,6 @@ function bool = ismonoinc(x)
 %
 %   Output parameter:
 %       bool    - boolean value
-%
-%   ISMONOTONIC(x) checks if the data in vector x are monotonic increasing.
 %
 %   See also: intpol_ir
 

--- a/SFS_general/isodd.m
+++ b/SFS_general/isodd.m
@@ -1,5 +1,5 @@
 function bool = isodd(number)
-%ISODD returns true for odd integer
+%ISODD true for odd integer
 %
 %   Usage: bool = isodd(number)
 %
@@ -8,8 +8,6 @@ function bool = isodd(number)
 %
 %   Output parameters:
 %       bool    - true if the number is odd, false else
-%
-%   ISODD(number) checks if the given number is odd.
 %
 %   See also: iseven
 

--- a/SFS_general/lagrange_filter.m
+++ b/SFS_general/lagrange_filter.m
@@ -1,5 +1,5 @@
 function b = lagrange_filter(Norder,fdt)
-%LAGRANGE_FILTER computes Lagrange interpolation filter for fractional delays
+%LAGRANGE_FILTER Lagrange interpolation filter for fractional delays
 %
 %   Usage: b = lagrange_filter(order,fdt)
 %

--- a/SFS_general/linkwitz_riley.m
+++ b/SFS_general/linkwitz_riley.m
@@ -1,6 +1,5 @@
 function [z,p,k] = linkwitz_riley(n,wc,ftype,domain)
-%LINKWITZ_RILEY computes zero-poles-gain representation in z-domain (digital)
-%or Laplace-domain (analog) of the Linkwitz-Riley filter
+%LINKWITZ_RILEY zero-poles-gain representation of the Linkwitz-Riley filter
 %
 %   Usage: [z,p,k] = linkwitz_riley(n,wc,ftype,[domain])
 %

--- a/SFS_general/modal_weighting.m
+++ b/SFS_general/modal_weighting.m
@@ -1,5 +1,5 @@
 function [win,varargout] = modal_weighting(order,Ninv,conf)
-%MODAL_WEIGHTING computes weighting window for modal coefficients
+%MODAL_WEIGHTING weighting window for modal coefficients
 %
 %   Usage: [win,Win,Ang] = modal_weighting(order,[Ninv],conf)
 %

--- a/SFS_general/nfchoa_order.m
+++ b/SFS_general/nfchoa_order.m
@@ -1,6 +1,5 @@
 function M = nfchoa_order(nls,conf)
-%NFCHOA_ORDER returns the maximum order for the spherical harmonics for the
-%given number of secondary sources
+%NFCHOA_ORDER maximum order of spatial band-limited NFC-HOA
 %
 %   Usage: M = nfchoa_order(nls,conf)
 %

--- a/SFS_general/norm_signal.m
+++ b/SFS_general/norm_signal.m
@@ -1,5 +1,5 @@
 function sig = norm_signal(sig)
-%NORM_SIGNAL normalizes the signal to 1-eps
+%NORM_SIGNAL normalizes the signal to the range ]-1:1[
 %
 %   Usage: sig = norm_signal(sig)
 %
@@ -8,9 +8,6 @@ function sig = norm_signal(sig)
 %
 %   Output parameters:
 %       sig - audio signal normalized to -1<sig<1
-%
-%   NORM_SIGNAL(sig) normalizes the amplitude of the given signal to the range
-%   of ]-1:1[.
 %
 %   See also: auralize_ir
 

--- a/SFS_general/pm_filter.m
+++ b/SFS_general/pm_filter.m
@@ -1,5 +1,5 @@
 function b = pm_filter(order,wpass,wstop)
-%PM_FILTER computes an FIR lowpass-filter using the Parks-McClellan Algorithm
+%PM_FILTER FIR lowpass-filter using the Parks-McClellan Algorithm
 %
 %   Usage: b = pm_filter(order,wpass,wstop)
 %

--- a/SFS_general/px2cm.m
+++ b/SFS_general/px2cm.m
@@ -3,13 +3,11 @@ function y = px2cm(x)
 %
 %   Usage: y = px2cm(x)
 %
-%   Input options:
+%   Input parameters:
 %       x     - input / px
 %
-%   Output options:
+%   Output parameters:
 %       y     - output / cm
-%
-%   PX2CM(x) returns the given value x in centimeters.
 %
 %   See also: px2in, in2cm, in2px, cm2px, cm2in
 

--- a/SFS_general/px2in.m
+++ b/SFS_general/px2in.m
@@ -3,13 +3,11 @@ function y = px2in(x)
 %
 %   Usage: y = px2in(x)
 %
-%   Input options:
+%   Input parameters:
 %       x     - input / px
 %
-%   Output options:
+%   Output parameters:
 %       y     - output / inches
-%
-%   PX2IN(x) returns the given value x in inches.
 %
 %   See also: px2cm, in2cm, in2px, cm2px, cm2in
 

--- a/SFS_general/rad.m
+++ b/SFS_general/rad.m
@@ -3,13 +3,11 @@ function phi = rad(phi)
 %
 %   Usage: phi = rad(phi)
 %
-%   Input options:
+%   Input parameters:
 %       phi     - angle, can be a scalar or matrix / degree
 %
-%   Output options:
+%   Output parameters:
 %       phi     - angle / rad
-%
-%   RAD(phi) returns the given angles phi in radians.
 %
 %   See also: deg
 

--- a/SFS_general/rotation_matrix.m
+++ b/SFS_general/rotation_matrix.m
@@ -1,5 +1,5 @@
 function R = rotation_matrix(phi,dim,orientation)
-%ROTATION_MATRIX returns a 3D rotation matrix for the given angle and dimension
+%ROTATION_MATRIX 3D rotation matrix
 %
 %   Usage: R = rotation_matrix(phi,[dim,[orientation]])
 %

--- a/SFS_general/rounded_box.m
+++ b/SFS_general/rounded_box.m
@@ -4,12 +4,12 @@ function [x0,n0,w0] = rounded_box(t,ratio)
 %
 %   Usage: [x0,n0,w0] = rounded_box(t,ratio)
 %
-%   Input options:
+%   Input parameters:
 %       t      - parameter indicating position on the boundary [1 x n]
 %       ratio  - ratio between bending radius of the rounded corners and the 
 %                half edge length of the rectangular bounding box (0,1) 
 %
-%   Output options:
+%   Output parameters:
 %       x0     - positions [n x 3]
 %       n0     - unit vector for boundaries normal vector [n x 3]
 %       w0     - weights for integration [n x 1]
@@ -35,7 +35,7 @@ function [x0,n0,w0] = rounded_box(t,ratio)
 %   element. The weights are computed on the distance of neighboring elements
 %   ALONG THE BOUNDARY of the box.
 %
-% See also: secondary_source_positions
+%   See also: secondary_source_positions
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_general/row_vector.m
+++ b/SFS_general/row_vector.m
@@ -1,5 +1,5 @@
 function varargout = row_vector(varargin)
-%ROW_VECTOR transforms the given vector to a row vector
+%ROW_VECTOR returns the given vectors as row vectors
 %
 %   Usage: [x1,x2,...] = row_vector(x1,x2,...)
 %
@@ -8,9 +8,6 @@ function varargout = row_vector(varargin)
 %
 %   Output parameters:
 %       x1,x2,...  - input vectors as row vectors
-%
-%   ROW_VECTOR(x1,x2,...) returns the given vectors x1,x2,... as row
-%   vectors.
 %
 %   See also: column_vector
 

--- a/SFS_general/secondary_source_diameter.m
+++ b/SFS_general/secondary_source_diameter.m
@@ -1,7 +1,5 @@
 function [diam,center] = secondary_source_diameter(conf)
-%SECONDARY_SOURCE_DIAMETER calculates the maximum distance
-% between the secondary sources (the diameter) and the center of the
-% smallest ball that contains the array.
+%SECONDARY_SOURCE_DIAMETER diameter and center of secondary sources
 %
 %   Usage: [diam,center] = secondary_source_diameter(conf)
 %

--- a/SFS_general/secondary_source_distance.m
+++ b/SFS_general/secondary_source_distance.m
@@ -1,6 +1,5 @@
 function [dx0,dx0_single] = secondary_source_distance(x0,approx)
-%SECONDARY_SOURCE_DISTANCE calculates the average distance between the secondary
-%sources
+%SECONDARY_SOURCE_DISTANCE average distance between secondary sources
 %
 %   Usage: dx0 = secondary_source_distance(x0,[approx])
 %

--- a/SFS_general/secondary_source_positions.m
+++ b/SFS_general/secondary_source_positions.m
@@ -1,13 +1,12 @@
 function x0 = secondary_source_positions(conf)
-%SECONDARY_SOURCE_POSITIONS generates the positions, directions, and weights of
-%   the secondary sources
+%SECONDARY_SOURCE_POSITIONS positions, directions, weights of secondary sources
 %
 %   Usage: x0 = secondary_source_positions(conf)
 %
-%   Input options:
+%   Input parameters:
 %       conf   - configuration struct (see SFS_config)
 %
-%   Output options:
+%   Output parameters:
 %       x0     - secondary source positions, directions and weights
 %                [x0 y0 z0 nx0 ny0 nz0 w] / m
 %

--- a/SFS_general/secondary_source_selection.m
+++ b/SFS_general/secondary_source_selection.m
@@ -1,9 +1,9 @@
 function [x0,idx] = secondary_source_selection(x0,xs,src)
-%SECONDARY_SOURCE_SELECTION selects which secondary sources are active
+%SECONDARY_SOURCE_SELECTION selects active secondary sources for WFS
 %
 %   Usage: [x0,idx] = secondary_source_selection(x0,xs,src)
 %
-%   Input options:
+%   Input parameters:
 %       x0          - secondary source positions, directions and weights / m [nx7]
 %       xs          - position and for focused sources also direction of the
 %                     desired source model / m [1x3] or [1x6] or [mx6]
@@ -15,17 +15,20 @@ function [x0,idx] = secondary_source_selection(x0,xs,src)
 %                       'fs'  - focused source
 %                       'vss' - distribution of focused sources for local WFS
 %
-%   Output options:
+%   Output parameters:
 %       x0          - secondary sources / m, containing only the active
 %                     ones [mx7]
 %       idx         - index of the selected sources from the original x0
 %                     matrix [mx1]
 %
 %   SECONDARY_SOURCE_SELECTION(x0,xs,src) returns only the active secondary
-%   sources for the given geometry and virtual source. In addition the index of
-%   the chosen secondary sources is returned.
+%   sources for the given geometry and virtual source in WFS. In addition the
+%   index of the chosen secondary sources is returned.
 %
 %   See also: secondary_source_positions, secondary_source_tapering
+%
+%   References:
+%       http://sfstoolbox.org
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_general/secondary_source_tapering.m
+++ b/SFS_general/secondary_source_tapering.m
@@ -3,11 +3,11 @@ function x0 = secondary_source_tapering(x0,conf)
 %
 %   Usage: x0 = secondary_source_tapering(x0,conf)
 %
-%   Input options:
+%   Input parameters:
 %       x0          - secondary sources / m
 %       conf        - configuration struct (see SFS_config)
 %
-%   Output options:
+%   Output parameters:
 %       x0          - secondary sources / m, containing the applied tapering
 %                     window in its weights in x0(:,7)
 %

--- a/SFS_general/signal_from_spectrum.m
+++ b/SFS_general/signal_from_spectrum.m
@@ -1,5 +1,5 @@
 function outsig = signal_from_spectrum(amplitude,phase,f,conf)
-%SIGNAL_FROM_SPECTRUM creates time signal from single-sided spectrum
+%SIGNAL_FROM_SPECTRUM time signal from single-sided spectrum
 %
 %   Usage: outsig = signal_from_spectrum(amplitude,phase,f,conf)
 %

--- a/SFS_general/spectrum_from_signal.m
+++ b/SFS_general/spectrum_from_signal.m
@@ -1,5 +1,5 @@
 function varargout = spectrum_from_signal(signal,conf)
-%SPECTRUM_FROM_SIGNAL returns single-sided amplitude and phase spectra of signal
+%SPECTRUM_FROM_SIGNAL single-sided amplitude and phase spectra of signal
 %
 %   Usage: [amplitude,phase,f] = spectrum_from_signal(sig,conf)
 %

--- a/SFS_general/sphbesselh.m
+++ b/SFS_general/sphbesselh.m
@@ -11,9 +11,6 @@ function out = sphbesselh(nu,k,z)
 %   Output parameters:
 %       out - value of Hankel function at point z
 %
-%   SPHBESSELH(nu,k,z) spherical Hankel function of order nu, kind k, and
-%   argument z
-%
 %   See also: sphbesselj, sphbessely
 
 %*****************************************************************************

--- a/SFS_general/sphbesselj.m
+++ b/SFS_general/sphbesselj.m
@@ -10,9 +10,6 @@ function out = sphbesselj(nu,z)
 %   Output parameters:
 %       out - value of bessel function at point z
 %
-%   SPHBESSELJ(nu,z) spherical bessel function of order nu, frist type, and
-%   argument z
-%
 %   See also: sphbesselh, sphbessely
 
 %*****************************************************************************

--- a/SFS_general/sphbessely.m
+++ b/SFS_general/sphbessely.m
@@ -1,6 +1,5 @@
 function out = sphbessely(nu,z)
-% SPHBESSELY spherical bessel function of second kind, of order nu, and
-% argument z
+%SPHBESSELY spherical bessel function of second kind, of order nu
 %
 %   Usage: out = sphbesselj(nu,z)
 %
@@ -10,9 +9,6 @@ function out = sphbessely(nu,z)
 %
 %   Output parameters:
 %       out - value of bessel function at point z
-%
-%   SPHBESSELY(nu,z) spherical bessel function of order nu, frist type, and
-%   argument z
 %
 %   See also: sphbesselh, sphbesselj
 

--- a/SFS_general/sphharmonics.m
+++ b/SFS_general/sphharmonics.m
@@ -1,5 +1,5 @@
 function [ Ynm ] = sphharmonics(n,m,theta,phi);
-% SPHHARMONICS spherical harmonics function
+% SPHHARMONICS spherical harmonics
 %
 %   Usage: Ynm = sphharmonics(n,m,theta,phi)
 %

--- a/SFS_general/tapering_window.m
+++ b/SFS_general/tapering_window.m
@@ -1,5 +1,5 @@
 function win = tapering_window(x0,conf)
-%TAPERING_WINDOW generates a tapering window for a loudspeaker array
+%TAPERING_WINDOW tapering window for secondary sources
 %
 %   Usage: win = tapering_window(x0,conf)
 %

--- a/SFS_general/thiran_filter.m
+++ b/SFS_general/thiran_filter.m
@@ -1,5 +1,5 @@
 function [b,a] = thiran_filter(Norder,fdt)
-%THIRAN_FILTER computes Thiran's IIR allpass for Maximally Flat Group Delay
+%THIRAN_FILTER Thiran's IIR allpass for Maximally Flat Group Delay
 %
 %   Usage: [b,a] = thiran_filter(order,fdt)
 %

--- a/SFS_general/vector_norm.m
+++ b/SFS_general/vector_norm.m
@@ -1,5 +1,5 @@
 function y = vector_norm(x,dim)
-%VECTOR_NORM calculates the norm for the rows/columns of a matrix
+%VECTOR_NORM norm for the rows/columns of a matrix
 %
 %   Usage: y = vector_norm(x,dim)
 %

--- a/SFS_general/vector_product.m
+++ b/SFS_general/vector_product.m
@@ -1,5 +1,5 @@
 function y = vector_product(x1,x2,dim)
-%VECTOR_PRODUCT calculates the scalar product for two vectors within matrices
+%VECTOR_PRODUCT scalar product for two vectors within matrices
 %
 %   Usage: y = vector_product(x1,x2,dim)
 %
@@ -10,9 +10,6 @@ function y = vector_product(x1,x2,dim)
 %
 %   Output parameter:
 %       y   - scalar product between the vectors [1 x m] or [n x 1]
-%
-%   VECTOR_PRODUCT(x1,x2,dim) calculates the scalar product between the vectors
-%   given within the matrices along the dimension dim.
 %
 %   See also: vector_norm
 

--- a/SFS_general/virtual_secondary_source_positions.m
+++ b/SFS_general/virtual_secondary_source_positions.m
@@ -1,10 +1,10 @@
 function xv = virtual_secondary_source_positions(x0,xs,src,conf)
-%VIRTUAL_SECONDARY_SOURCE_POSITIONS generates the positions and directions of a
+%VIRTUAL_SECONDARY_SOURCE_POSITIONS positions and directions of a
 %   virtual secondary source distribution
 %
 %   Usage: xv = virtual_secondary_source_positions(x0,xs,src,conf)
 %
-%   Input options:
+%   Input parameters:
 %       x0          - positions, directions and weights of real secondary
 %                     sources [nx7]
 %       xs          - position and for focused sources also direction of the
@@ -16,7 +16,7 @@ function xv = virtual_secondary_source_positions(x0,xs,src,conf)
 %                       'fs' - focused source (not supported, yet)
 %       conf        - configuration struct (see SFS_config)
 %
-%   Output options:
+%   Output parameters:
 %       xv          - virtual secondary source positions, directions and
 %                     weights / m
 %

--- a/SFS_general/weights_for_points_on_a_sphere_rectangle.m
+++ b/SFS_general/weights_for_points_on_a_sphere_rectangle.m
@@ -1,6 +1,6 @@
 function [w] = weights_for_points_on_a_sphere_rectangle(phi,theta)
-%WEIGHTS_FOR_POINTS_ON_A_SPHERE_RECTANGLE returns the weights for a given
-% set of points on a sphere.
+%WEIGHTS_FOR_POINTS_ON_A_SPHERE_RECTANGLE weights for a given set of points
+%on a sphere.
 %
 %   Usage: [w] = weights_for_points_on_a_sphere_rectangle(phi,theta)
 %

--- a/SFS_general/xyz_axes_selection.m
+++ b/SFS_general/xyz_axes_selection.m
@@ -4,17 +4,17 @@ function [dimensions,x1,x2,x3] = xyz_axes_selection(x,y,z)
 %
 %   Usage: [dimensions,x1,x2,x3] = xyz_axes_selection(x,y,z)
 %
-%   Input options:
+%   Input parameters:
 %       x,y,z      - vectors/matrices containing the x-, y- and z-axis values / m
 %
-%   Output options:
+%   Output parameters:
 %       dimensions - 1x3 vector containing 1 or 0 to indicate the activity
 %                    of the single dimensions in the order [x y z]
 %       x1         - vector/matrix containing the first axis / m
 %       x2         - vector/matrix containing the second axis / m
 %       x3         - vector/matrix containing the third axis / m
 %
-%   XYZ_AXES_SELECTION(x,y,z) returns a indicating vector for the x-, y- and
+%   XYZ_AXES_SELECTION(x,y,z) returns an indication vector for the x-, y- and
 %   z-axis if we have any activity on this axis or if it is a singleton axis.
 %   In addition, the axes are reordered starting first with the non-singleton
 %   axes.

--- a/SFS_general/xyz_grid.m
+++ b/SFS_general/xyz_grid.m
@@ -1,5 +1,5 @@
 function [xx,yy,zz] = xyz_grid(X,Y,Z,conf)
-%XYZ_GRID returns a xyz-grid for the listening area
+%XYZ_GRID returns xyz-grid for the listening area
 %
 %   Usage: [xx,yy,zz] = xyz_grid(X,Y,Z,conf)
 %

--- a/SFS_helper/get_position_and_orientation_ls.m
+++ b/SFS_helper/get_position_and_orientation_ls.m
@@ -1,14 +1,13 @@
 function [xs,nxs] = get_position_and_orientation_ls(xs,conf);
-%GET_POSITION_AND_ORIENTATION_LS returns [nx3] position and [nx3] orientation
-%for a line source
+%GET_POSITION_AND_ORIENTATION_LS position and orientation for a line source
 %
 %   Usage: [xs,nxs] = get_position_and_orientation_ls(xs,conf);
 %
-%   Input options:
+%   Input parameters:
 %       xs          - combined position and orientation / m [nx3] or [nx6]
 %       args        - list of args
 %
-%   Output options:
+%   Output parameters:
 %       xs          - position of line source / m [nx3]
 %       nxs         - orientation of line source / m [nx3]
 %

--- a/SFS_helper/get_sfs_path.m
+++ b/SFS_helper/get_sfs_path.m
@@ -1,5 +1,5 @@
 function path = get_sfs_path()
-%GET_SFS_PATH returns the base path of the SFS Toolbox
+%GET_SFS_PATH base path of the SFS Toolbox
 %
 %   Usage: path = get_sfs_path();
 %

--- a/SFS_helper/isargchar.m
+++ b/SFS_helper/isargchar.m
@@ -1,13 +1,10 @@
 function isargchar(varargin)
-%ISARGCHAR tests if the given arg is a char and returns an error otherwise
+%ISARGCHAR throws an error if not a char
 %
 %   Usage: isargstruct(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGCHAR(args) tests if all given args are a char and returns
-%   an error otherwise.
 %
 %   See also: isargstruct
 

--- a/SFS_helper/isargcoord.m
+++ b/SFS_helper/isargcoord.m
@@ -1,9 +1,9 @@
 function isargcoord(varargin)
-%ISARGCOORD tests if the given arg is a point in an euclidian coordinate system
+%ISARGCOORD throws an error if not a point in an euclidian coordinate system
 %
 %   Usage: isargcoord(args)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
 %
 %   ISARGCOORD(args) tests if all given args are a point in an euclidian

--- a/SFS_helper/isargdir.m
+++ b/SFS_helper/isargdir.m
@@ -1,13 +1,10 @@
 function isargdir(varargin)
-%ISARGDIR tests if the given arg is a directory
+%ISARGDIR throws an error if not a directory
 %
 %   Usage: isargdirectory(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - variable number of args
-%
-%   ISARGDIR(args) tests if all given args are a directory and
-%   returns an error otherwise.
 %
 %   See also: isargfile
 

--- a/SFS_helper/isargequallength.m
+++ b/SFS_helper/isargequallength.m
@@ -1,13 +1,10 @@
 function isargequallength(x1,varargin)
-%ISARGEQUALSIZE tests if the given arrays have the same size
+%ISARGEQUALSIZE throws an error if not the same length
 %
 %   Usage: isargequallength(x1,x2,...)
 %
-%   Input options:
+%   Input parameters:
 %       x1,x2,...   - matrices to test
-%
-%   ISARGEQUALLENGTH(x1,x2,...) tests if all given arigs have the same size.
-%   Reports an error otherwise.
 %
 %   See also: isargequalsize
 

--- a/SFS_helper/isargequalsize.m
+++ b/SFS_helper/isargequalsize.m
@@ -1,13 +1,10 @@
 function isargequalsize(x1,varargin)
-%ISARGEQUALSIZE tests if the given arrays have the same size
+%ISARGEQUALSIZE throws an error if not the same size
 %
 %   Usage: isargequalsize(x1,x2,...)
 %
-%   Input options:
+%   Input parameters:
 %       x1,x2,...   - matrices to test
-%
-%   ISARGEQUALSIZE(x1,x2,...) tests if all given arrays have the same size.
-%   Reports an error otherwise.
 %
 %   See also: isargequallength
 

--- a/SFS_helper/isargfile.m
+++ b/SFS_helper/isargfile.m
@@ -1,13 +1,10 @@
 function isargfile(varargin)
-%ISARGFILE tests if the given arg is a file and returns an error otherwise
+%ISARGFILE throws an error if not a file
 %
 %   Usage: isargfile(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGFILE(args) tests if all given args are a file and returns
-%   an error otherwise.
 %
 %   See also: isargdir
 

--- a/SFS_helper/isargmatrix.m
+++ b/SFS_helper/isargmatrix.m
@@ -1,13 +1,10 @@
 function isargmatrix(varargin)
-%ISARGMATRIX tests if the given arg is a matrix and returns an error otherwise
+%ISARGMATRIX throws an error if not a matrix
 %
 %   Usage: isargmatrix(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGMATRIX(args) tests if all given args are a matrix and returns
-%   an error otherwise.
 %
 %   See also: isargvector, isargscalar
 

--- a/SFS_helper/isargnegativescalar.m
+++ b/SFS_helper/isargnegativescalar.m
@@ -1,13 +1,10 @@
 function isargnegativescalar(varargin)
-%ISARGNEGATIVESCALAR tests if the given arg is a negative scalar
+%ISARGNEGATIVESCALAR throws an error if not a negative scalar
 %
 %   Usage: isargnegativescalar(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGNEGATIVESCALAR(args) tests if all given args are a negative
-%   scalar and returns an error otherwise.
 %
 %   See also: isargscalar, isargpositivescalar
 

--- a/SFS_helper/isargnumeric.m
+++ b/SFS_helper/isargnumeric.m
@@ -1,13 +1,10 @@
 function isargnumeric(varargin)
-%ISARGNUMERIC tests if the given arg is numeric and returns an error otherwise
+%ISARGNUMERIC throws an error if not numeric
 %
 %   Usage: isargnumeric(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGNUMRIC(args) tests if all given args are numeric and returns
-%   an error otherwise.
 %
 %   See also: isargscalar
 

--- a/SFS_helper/isargposition.m
+++ b/SFS_helper/isargposition.m
@@ -1,14 +1,10 @@
 function isargposition(varargin)
-%ISARGPOSITION tests if the given arg is a [1x3] vector and returns an error
-%otherwise
+%ISARGPOSITION throws an error if not a [1x3] vector
 %
 %   Usage: isargposition(args)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGPOSITION(args) tests if all given args are [1x3] vectors and
-%   returns an error otherwise.
 %
 %   See also: isargscalar, isargvector, isargxs
 

--- a/SFS_helper/isargpositivescalar.m
+++ b/SFS_helper/isargpositivescalar.m
@@ -1,13 +1,10 @@
 function isargpositivescalar(varargin)
-%ISARGPOSITIVESCALAR tests if the given arg is a positive scalar
+%ISARGPOSITIVESCALAR throws an error if not a positive scalar
 %
 %   Usage: isargpositivescalar(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGPOSITIVESCALAR(args) tests if all given args are a positive
-%   scalar and returns an error otherwise.
 %
 %   See also: isargscalar, isargnegativescalar
 

--- a/SFS_helper/isargscalar.m
+++ b/SFS_helper/isargscalar.m
@@ -1,12 +1,10 @@
 function isargscalar(varargin)
-%ISARGSCALAR tests if the given arg is a scalar and returns an error otherwise
+%ISARGSCALAR throws an error if not a scalar
+%
 %   Usage: isargscalar(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGSCALAR(args) tests if all given args are a scalar and returns
-%   an error otherwise.
 %
 %   See also: isargpositivescalar
 

--- a/SFS_helper/isargsecondarysource.m
+++ b/SFS_helper/isargsecondarysource.m
@@ -1,10 +1,9 @@
 function isargsecondarysource(varargin)
-%ISARGSECONDARYSOURCE tests if the given arg is a matrix containing secondary
-%   source positions and directions and return an error otherwise
+%ISARGSECONDARYSOURCE throws an error if not secondary sources
 %
 %   Usage: isargsecondarysource(args)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
 %
 %   ISARGSECONDARYSOURCE(args) tests if all given args are a matrix

--- a/SFS_helper/isargstruct.m
+++ b/SFS_helper/isargstruct.m
@@ -1,13 +1,10 @@
 function isargstruct(varargin)
-%ISARGSTRUCT tests if the given arg is a struct and returns an error otherwise
+%ISARGSTRUCT throws an error if not a struct
 %
 %   Usage: isargstruct(arg1,arg2,...)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGSTRUCT(args) tests if all given args are a struct and returns
-%   an error otherwise.
 %
 %   See also: isargchar
 

--- a/SFS_helper/isargvector.m
+++ b/SFS_helper/isargvector.m
@@ -1,13 +1,10 @@
 function isargvector(varargin)
-%ISARGVECTOR tests if the given arg is a vector and returns an error otherwise
+%ISARGVECTOR throws an error if not a vector
 %
 %   Usage: isargvector(args)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGVECTOR(args) tests if all given args are a vector and returns
-%   an error otherwise.
 %
 %   See also: isargscalar, isargmatrix
 

--- a/SFS_helper/isargxs.m
+++ b/SFS_helper/isargxs.m
@@ -1,14 +1,10 @@
 function isargxs(varargin)
-%ISARGXS tests if the given args are a [1x3] and/or [1x6] vector and returns
-%an error otherwise
+%ISARGXS throws an error if not a [1x3] and/or [1x6] vector
 %
 %   Usage: isargxs(args)
 %
-%   Input options:
+%   Input parameters:
 %       args        - list of args
-%
-%   ISARGXS(args) tests if all given args are a [1x3] and/or [1x6]  vectors and
-%   returns an error otherwise.
 %
 %   See also: isargscalar, isargvector, isargposition
 

--- a/SFS_helper/isoctave.m
+++ b/SFS_helper/isoctave.m
@@ -1,10 +1,13 @@
 function bool = isoctave()
-%ISOCTAVE  True if the operating environment is octave.
+%ISOCTAVE true if the operating environment is octave
 %
-%   Usage: t = isoctave();
+%   Usage: status = isoctave();
 %
-%   ISOCTAVE returns 1 if the operating environment is Octave, otherwise
-%   0 (Matlab)
+%   Output parameters:
+%       status - boolean
+%
+%   See also: iswindows
+
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_helper/iswindows.m
+++ b/SFS_helper/iswindows.m
@@ -1,9 +1,12 @@
 function bool = iswindows()
-%ISWINDOWS  True if the operating system is Windows
+%ISWINDOWS true if the operating system is Windows
 %
 %   Usage: status = iswindows();
 %
-%   ISWINDOWS returns 1 if the operating system is Windows, otherwise 0
+%   Output parameters:
+%       status - boolean
+%
+%   See also: isoctave
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_helper/progress_bar.m
+++ b/SFS_helper/progress_bar.m
@@ -1,5 +1,5 @@
 function progress_bar(ii,nii,message)
-%PROGRESS_BAR show a progress of an iteration
+%PROGRESS_BAR show the progress of an iteration
 %
 %   Usage: progress_bar(ii,nii,[message])
 %
@@ -7,9 +7,6 @@ function progress_bar(ii,nii,message)
 %       ii      - current iteration
 %       nii     - number of iterations
 %       message - string printed before progress bar (default: 'Progress')
-%
-%   PROGRESS_BAR(ii,nii,message) displays the progress of a loop.
-%
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_helper/to_be_implemented.m
+++ b/SFS_helper/to_be_implemented.m
@@ -1,5 +1,5 @@
 function to_be_implemented(mfile)
-%TO_BE_IMPLEMENTED indicates that the code had to be implemented
+%TO_BE_IMPLEMENTED throws an error indicating missing code
 %
 %   Usage: to_be_implemented([mfilename])
 %
@@ -7,9 +7,6 @@ function to_be_implemented(mfile)
 %       mfilename   - string containing the name of the calling m file.
 %                   NOTE: this variable is already available in all m files as
 %                   mfilename!
-%
-%   TO_BE_IMPLEMENTED(mfilename) results in an error that indicates the desired
-%   code functionality has to be implemented yet.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_ir/dummy_irs.m
+++ b/SFS_ir/dummy_irs.m
@@ -1,5 +1,5 @@
 function sofa = dummy_irs(nsamples,conf)
-% DUMMY_IRS creates a dummy dirac pulse impulse response set
+%DUMMY_IRS dirac pulse impulse response SOFA dataset
 %
 %   Usage: irs = dummy_irs([nsamples],conf)
 %

--- a/SFS_ir/get_ir.m
+++ b/SFS_ir/get_ir.m
@@ -1,5 +1,5 @@
 function ir = get_ir(sofa,X,head_orientation,xs,coordinate_system,conf)
-%GET_IR returns an impulse response for the given apparent angle
+%GET_IR impulse response for the given apparent angle
 %
 %   Usage: ir = get_ir(sofa,X,head_orientation,xs,coordinate_system,conf)
 %

--- a/SFS_ir/ir_correct_distance.m
+++ b/SFS_ir/ir_correct_distance.m
@@ -1,5 +1,5 @@
 function ir = ir_correct_distance(ir,ir_distance,r,conf)
-%IR_CORRECT_DISTANCE weights and delays the impulse reponse for a desired
+%IR_CORRECT_DISTANCE weights and delays an impulse reponse for a desired
 %distance
 %
 %   Usage: ir = ir_correct_distance(ir,ir_distance,r,conf)

--- a/SFS_ir/reduce_ir.m
+++ b/SFS_ir/reduce_ir.m
@@ -1,5 +1,5 @@
 function short_ir = reduce_ir(ir,fs,nsamples,conf)
-%REDUCE_IR resamples and shortens a IR
+%REDUCE_IR resamples and shortens an impulse response
 %
 %   Usage: ir = reduce_ir(ir,fs,nsamples,conf)
 %

--- a/SFS_ir/sofa2brs.m
+++ b/SFS_ir/sofa2brs.m
@@ -10,10 +10,10 @@ function brs = sofa2brs(sofa)
 %       brs     - brs data set
 %
 %   SOFA2BRS(sofa) converts a the given sofa file or struct into a brs set
-%   suitable for th SoundScape Renderer. The brs data set is a matrix
-%   containing the channels for all directions. As the SoundScape Renderer is
-%   currently only working in the horizontal plane, only impulse responses from
-%   the sofa data set are used with an elevation of 0.
+%   suitable for th SoundScape Renderer. The brs data set is a matrix containing
+%   the channels for all directions. As the SoundScape Renderer is currently
+%   only working in the horizontal plane, only impulse responses from the sofa
+%   data set are used with an elevation of 0.
 %
 %   See also: sofa_get_header, sofa_get_data, SOFAcalculateAPV
 

--- a/SFS_ir/sofa_get_data_fir.m
+++ b/SFS_ir/sofa_get_data_fir.m
@@ -1,5 +1,5 @@
 function ir = sofa_get_data_fir(sofa,idx)
-%SOFA_GET_DATA_FIR returns impulse responses from a SOFA file or struct
+%SOFA_GET_DATA_FIR returns a FIR data matrix from a SOFA file or struct
 %
 %   Usage: ir = sofa_get_data_fir(sofa,[idx])
 %

--- a/SFS_ir/sofa_get_data_fire.m
+++ b/SFS_ir/sofa_get_data_fire.m
@@ -1,5 +1,5 @@
 function ir = sofa_get_data_fire(sofa,idxM,idxE)
-%SOFA_GET_DATA_FIRE returns impulse responses from a SOFA file or struct
+%SOFA_GET_DATA_FIRE returns a FIRE data matrix from a SOFA file or struct
 %
 %   Usage: ir = sofa_get_data_fire(sofa,[idxM],[idxE])
 %

--- a/SFS_ir/sofa_get_head_orientations.m
+++ b/SFS_ir/sofa_get_head_orientations.m
@@ -13,8 +13,8 @@ function [phi,theta,r] = sofa_get_head_orientations(sofa,idx)
 %       theta  - head orientations in the median plane / rad
 %       r      - head orientations radii / m
 %
-%   SOFA_GET_HEAD_ORIENTATIONS(sofa,idx) returns head orientation [phi,theta,r] as
-%   defined in the given SOFA file or struct, specified by idx. If no idx is
+%   SOFA_GET_HEAD_ORIENTATIONS(sofa,idx) returns head orientation [phi,theta,r]
+%   as defined in the given SOFA file or struct, specified by idx. If no idx is
 %   specified, all head orientations are returned.
 %
 %   See also: get_ir, sofa_get_header, sofa_get_secondary_sources

--- a/SFS_ir/sofa_get_listener_position.m
+++ b/SFS_ir/sofa_get_listener_position.m
@@ -14,8 +14,8 @@ function X = sofa_get_listener_position(sofa,coordinate_system)
 %   Output parameters:
 %       X                 - listener position
 %
-%   SOFA_GET_LISTENER_POSITION(sofa,coordinate_system) returns listener position X
-%   as defined in the given SOFA file or struct.
+%   SOFA_GET_LISTENER_POSITION(sofa,coordinate_system) returns listener position
+%   X as defined in the given SOFA file or struct.
 %
 %   See also: get_ir, sofa_get_header, sofa_get_listener_view
 

--- a/SFS_ir/sofa_get_secondary_sources.m
+++ b/SFS_ir/sofa_get_secondary_sources.m
@@ -17,8 +17,8 @@ function [x0,nss] = sofa_get_secondary_sources(sofa,idx,coordinate_system)
 %       nss     - number of secondary sources
 %
 %   SOFA_GET_SECONDARY_SOURCES(sofa,idx,coordinate_system) returns secondary
-%   sources as defined in the given SOFA file or struct, specified by idx.
-%   If no idx is specified all secondary sources are returned. The coordinate
+%   sources as defined in the given SOFA file or struct, specified by idx.  If
+%   no idx is specified all secondary sources are returned. The coordinate
 %   system the position and direction of the secondary sources are specified in
 %   can be given by the string 'coordinate_system', 'cartesian' is assumed as
 %   default.

--- a/SFS_ir/sofa_is_file.m
+++ b/SFS_ir/sofa_is_file.m
@@ -1,5 +1,5 @@
 function boolean = sofa_is_file(sofa)
-%SOFA_CHECK returns 1 for a sofa file, 0 for a sofa struct or an error otherwise
+%SOFA_CHECK true for a sofa file, false for a sofa struct, throws an error else
 %
 %   Usage: number = sofa_check(sofa)
 %

--- a/SFS_monochromatic/circexp_mono/circexp_mono_ps.m
+++ b/SFS_monochromatic/circexp_mono/circexp_mono_ps.m
@@ -1,5 +1,5 @@
 function Pm = circexp_mono_ps(xs,Nce,f,xq,fhp,conf)
-%CIRCEXP_MONO_PS calculates the circular basis expansion of a point source
+%CIRCEXP_MONO_PS circular basis expansion of a mono-frequent point source
 %
 %   Usage: Pm = circexp_mono_ps(xs,Nce,f,xq,[fhp],conf)
 %
@@ -14,9 +14,6 @@ function Pm = circexp_mono_ps(xs,Nce,f,xq,fhp,conf)
 %   Output parameters:
 %       Pm      - regular circular expansion coefficients
 %                 for m = 0:Nce, [1 x Nce+1]
-%
-%   CIRCEXP_MONO_PS(xs,Nce,f,xq,fhp,conf) returns the circular basis expansion
-%   of a point source.
 %
 %   See also: circexp_mono_pw
 

--- a/SFS_monochromatic/circexp_mono/circexp_mono_pw.m
+++ b/SFS_monochromatic/circexp_mono/circexp_mono_pw.m
@@ -1,5 +1,5 @@
 function Pm = circexp_mono_pw(npw,Nce,f,xq,conf)
-%CIRCEXP_MONO_PW calculates the circular basis expansion of a plane wave
+%CIRCEXP_MONO_PW circular basis expansion of a mono-freqeunt plane wave
 %
 %   Usage: Pm = circexp_mono_pw(npw,Nce,xq,conf)
 %
@@ -13,9 +13,6 @@ function Pm = circexp_mono_pw(npw,Nce,f,xq,conf)
 %   Output parameters:
 %       Pm      - regular circular expansion coefficients
 %                 for m = 0:Nce, [1 x Nce+1]
-%
-%   CIRCEXP_MONO_PW(npw,Nce,xq,conf) returns the circular basis expansion of
-%   a plane wave.
 %
 %   See also: circexp_mono_ps
 

--- a/SFS_monochromatic/driving_function_mono_localwfs_sbl.m
+++ b/SFS_monochromatic/driving_function_mono_localwfs_sbl.m
@@ -1,6 +1,6 @@
 function D = driving_function_mono_localwfs_sbl(x0,xs,src,f,conf)
-%DRIVING_FUNCTION_MONO_LOCALWFS_SBL returns the driving signal for local WFS
-%using spatial bandwidth limitation
+%DRIVING_FUNCTION_MONO_LOCALWFS_SBL driving signal for local WFS using spatial
+%bandwidth limitation
 %
 %   Usage: D = driving_function_mono_localwfs_sbl(x0,xs,src,f,conf)
 %

--- a/SFS_monochromatic/driving_function_mono_localwfs_vss.m
+++ b/SFS_monochromatic/driving_function_mono_localwfs_vss.m
@@ -1,5 +1,6 @@
 function [D,x0,xv,idx] = driving_function_mono_localwfs_vss(x0,xs,src,f,conf)
-%DRIVING_FUNCTION_MONO_LOCALWFS_VSS returns the driving signal D for local WFS
+%DRIVING_FUNCTION_MONO_LOCALWFS_VSS driving signal for local WFS using virtual
+%secondary sources
 %
 %   Usage: [D,xv,x0,idx] = driving_function_mono_localwfs_vss(x0,xs,src,f,conf)
 %

--- a/SFS_monochromatic/driving_function_mono_nfchoa.m
+++ b/SFS_monochromatic/driving_function_mono_nfchoa.m
@@ -1,5 +1,5 @@
 function D = driving_function_mono_nfchoa(x0,xs,src,f,conf)
-%DRIVING_FUNCTION_MONO_NFCHOA returns the driving signal D for NFCHOA
+%DRIVING_FUNCTION_MONO_NFCHOA driving signal for NFC-HOA
 %
 %   Usage: D = driving_function_mono_nfchoa(x0,xs,src,f,conf)
 %
@@ -19,10 +19,6 @@ function D = driving_function_mono_nfchoa(x0,xs,src,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_NFCHOA(x0,xs,f,src,conf) returns the driving signal for
-%   the given secondary source and desired source type (src) for NFCHOA for the
-%   given frequency.
 %
 %   See also: plot_sound_field, sound_field_mono_nfchoa,
 %             driving_function_imp_nfchoa

--- a/SFS_monochromatic/driving_function_mono_sdm.m
+++ b/SFS_monochromatic/driving_function_mono_sdm.m
@@ -1,5 +1,5 @@
 function D = driving_function_mono_sdm(x0,xs,src,f,conf)
-%DRIVING_FUNCTION_MONO_SDM returns the driving signal D for SDM
+%DRIVING_FUNCTION_MONO_SDM driving signal for SDM
 %
 %   Usage: D = driving_function_mono_sdm(x0,xs,src,f,conf)
 %
@@ -17,10 +17,6 @@ function D = driving_function_mono_sdm(x0,xs,src,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM(x0,xs,f,src,conf) returns the driving signal for
-%   the given secondary sources, desired source type (src), and frequency.
-%   To derive the driving signals the spectral division method (SDM) is used.
 %
 %   See also: plot_sound_field, sound_field_mono_sdm, driving_function_imp_sdm
 

--- a/SFS_monochromatic/driving_function_mono_sdm_kx.m
+++ b/SFS_monochromatic/driving_function_mono_sdm_kx.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_sdm_kx(kx,xs,src,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_KX returns the driving signal D for SDM in the kx
-%domain
+%DRIVING_FUNCTION_MONO_SDM_KX driving signal for SDM in the kx-domain
 %
 %   Usage: D = driving_function_mono_sdm_kx(kx,xs,src,f,conf)
 %
@@ -18,11 +17,6 @@ function D = driving_function_mono_sdm_kx(kx,xs,src,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_KX(kx,xs,f,src,conf) returns the driving signal for
-%   the given secondary sources, desired source type (src), and frequency.
-%   To derive the driving signals the spectral division method (SDM) in the kx
-%   domain is used.
 %
 %   See also: plot_sound_field, sound_field_mono_sdm_kx
 

--- a/SFS_monochromatic/driving_function_mono_wfs.m
+++ b/SFS_monochromatic/driving_function_mono_wfs.m
@@ -1,5 +1,5 @@
 function D = driving_function_mono_wfs(x0,xs,src,f,conf)
-%DRIVING_FUNCTION_MONO_WFS returns the driving signal D for WFS
+%DRIVING_FUNCTION_MONO_WFS driving signal for WFS
 %
 %   Usage: D = driving_function_mono_wfs(x0,xs,src,f,conf)
 %
@@ -18,10 +18,6 @@ function D = driving_function_mono_wfs(x0,xs,src,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_WFS(x0,xs,f,src,conf) returns the driving signal for
-%   the given secondary source and desired source type (src) for WFS for the
-%   given frequency.
 %
 %   See also: plot_sound_field, sound_field_mono_wfs_25d,
 %             driving_function_imp_wfs_25d

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_ps.m
@@ -1,6 +1,6 @@
 function D = driving_function_mono_localwfs_sbl_ps(x0,xs,f,conf)
-%DRIVING_FUNCTION_MONO_LOCALWFS_SBL_PS returns the driving signal for a point 
-%source using local WFS with spatial bandwidth limitation
+%DRIVING_FUNCTION_MONO_LOCALWFS_SBL_PS driving signal for a point source using
+%local WFS with spatial bandwidth limitation
 %
 %   Usage: D = driving_function_mono_localwfs_sbl_ps(x0,xs,f,conf)
 %

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_pw.m
@@ -1,6 +1,6 @@
 function D = driving_function_mono_localwfs_sbl_pw(x0,nk,f,conf)
-%DRIVING_FUNCTION_MONO_LOCALWFS_SBL_PW returns the driving signal for a plane
-%wave using local WFS with spatial bandwidth limitation
+%DRIVING_FUNCTION_MONO_LOCALWFS_SBL_PW driving signal for a plane wave using
+%local WFS with spatial bandwidth limitation
 %
 %   Usage: D = driving_function_mono_localwfs_sbl_pw(x0,nk,f,conf)
 %

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_fs.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_nfchoa_fs(x0,xs,f,N,conf)
-%DRIVING_FUNCTION_MONO_NFCHOA_FS returns the driving signal D for a focused source
-%in NFCHOA
+%DRIVING_FUNCTION_MONO_NFCHOA_FS driving signal for a focused source in NFC-HOA
 %
 %   Usage: D = driving_function_mono_nfchoa_fs(x0,xs,f,N,conf)
 %
@@ -13,10 +12,6 @@ function D = driving_function_mono_nfchoa_fs(x0,xs,f,N,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_NFCHOA_FS(x0,xs,f,N,conf) returns NFCHOA driving
-%   signals for the given secondary sources, the focused source position
-%   and the frequency f.
 %
 %   See also: driving_function_mono_nfchoa, driving_function_imp_nfchoa_fs
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_ls.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_ls.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_nfchoa_ls(x0,xs,f,N,conf)
-%DRIVING_FUNCTION_MONO_NFCHOA_LS returns the driving signal D for a line source
-%in NFCHOA
+%DRIVING_FUNCTION_MONO_NFCHOA_LS driving signal for a line source in NFC-HOA
 %
 %   Usage: D = driving_function_mono_nfchoa_ls(x0,xs,f,N,conf)
 %
@@ -14,10 +13,6 @@ function D = driving_function_mono_nfchoa_ls(x0,xs,f,N,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_NFCHOA_LS(x0,xs,f,N,conf) returns NFCHOA driving
-%   signals for the given secondary sources, the virtual line source position
-%   and the frequency f.
 %
 %   See also: driving_function_mono_nfchoa, driving_function_imp_nfchoa_ls
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_ps.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_nfchoa_ps(x0,xs,f,N,conf)
-%DRIVING_FUNCTION_MONO_NFCHOA_PS returns the driving signal D for a point source
-%in NFCHOA
+%DRIVING_FUNCTION_MONO_NFCHOA_PS driving signal for a point source in NFC-HOA
 %
 %   Usage: D = driving_function_mono_nfchoa_ps(x0,xs,f,N,conf)
 %
@@ -13,10 +12,6 @@ function D = driving_function_mono_nfchoa_ps(x0,xs,f,N,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_NFCHOA_PS(x0,xs,f,N,conf) returns NFCHOA driving
-%   signals for the given secondary sources, the virtual point source position
-%   and the frequency f.
 %
 %   See also: driving_function_mono_nfchoa, driving_function_imp_nfchoa_ps
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_pw.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_nfchoa_pw(x0,nk,f,N,conf)
-%DRIVING_FUNCTION_MONO_NFCHOA_PW returns the driving signal D for a plane wave
-%in NFCHOA
+%DRIVING_FUNCTION_MONO_NFCHOA_PW driving signal for a plane wave in NFC-HOA
 %
 %   Usage: D = driving_function_mono_nfchoa_pw(x0,nk,f,N,conf)
 %
@@ -13,10 +12,6 @@ function D = driving_function_mono_nfchoa_pw(x0,nk,f,N,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_NFCHOA_PW(x0,nk,f,N,conf) returns NFCHOA driving
-%   signals for the given secondary sources, the virtual plane wave direction
-%   and the frequency f.
 %
 %   See also: driving_function_mono_nfchoa, driving_function_imp_nfchoa_pw
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_fs.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_sdm_fs(x0,nk,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_FS returns the driving signal D for a focused source in
-%SDM
+%DRIVING_FUNCTION_MONO_SDM_FS driving signal for a focused source in SDM
 %
 %   Usage: D = driving_function_mono_sdm_fs(x0,nk,f,conf)
 %
@@ -12,10 +11,6 @@ function D = driving_function_mono_sdm_fs(x0,nk,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_FS(x0,nk,f,conf) returns SDM driving signals
-%   for the given secondary sources, the virtual focused source position and the
-%   frequency f.
 %
 %   See also: driving_function_mono_sdm
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_fs.m
@@ -1,6 +1,6 @@
 function D = driving_function_mono_sdm_kx_fs(kx,xs,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_KX_FS returns the driving signal D for a focused source in
-%SDM in the kx domain
+%DRIVING_FUNCTION_MONO_SDM_KX_FS driving signal for a focused source SDM in
+%the kx-domain
 %
 %   Usage: D = driving_function_mono_sdm_kx_fs(kx,xs,f,conf)
 %
@@ -12,10 +12,6 @@ function D = driving_function_mono_sdm_kx_fs(kx,xs,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_KX_FS(kx,xs,f,conf) returns SDM driving signals
-%   for the given secondary sources, the focused source direction and the
-%   frequency f. The driving signal is calculated in the kx domain.
 %
 %   See also: driving_function_mono_wfs, driving_function_imp_wfs_ps
 %

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_ls.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_ls.m
@@ -1,6 +1,6 @@
 function D = driving_function_mono_sdm_kx_ls(kx,xs,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_KX_LS returns the driving signal D for a line source in
-%SDM in the kx domain
+%DRIVING_FUNCTION_MONO_SDM_KX_LS driving signal for a line source in SDM in
+%the kx-domain
 %
 %   Usage: D = driving_function_mono_sdm_kx_ps(kx,xs,f,conf)
 %
@@ -12,10 +12,6 @@ function D = driving_function_mono_sdm_kx_ls(kx,xs,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_KX_LS(kx,xs,f,conf) returns SDM driving signals
-%   for the given secondary sources, the virtual line source position and the
-%   frequency f. The driving signal is calculated in the kx domain.
 %
 %   See also: driving_function_mono_sdm_kx
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_ps.m
@@ -1,6 +1,6 @@
 function D = driving_function_mono_sdm_kx_ps(kx,xs,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_KX_PS returns the driving signal D for a point source in
-%SDM in the kx domain
+%DRIVING_FUNCTION_MONO_SDM_KX_PS driving signal for a point source in SDM in
+%the kx-domain
 %
 %   Usage: D = driving_function_mono_sdm_kx_ps(kx,xs,f,conf)
 %
@@ -12,10 +12,6 @@ function D = driving_function_mono_sdm_kx_ps(kx,xs,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_KX_PS(kx,xs,f,conf) returns SDM driving signals
-%   for the given secondary sources, the virtual point source position and the
-%   frequency f. The driving signal is calculated in the kx domain.
 %
 %   See also: driving_function_mono_sdm_kx
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_pw.m
@@ -1,6 +1,6 @@
 function D = driving_function_mono_sdm_kx_pw(kx,nk,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_KX_PW returns the driving signal D for a plane wave in
-%SDM in the kx domain
+%DRIVING_FUNCTION_MONO_SDM_KX_PW driving signal for a plane wave in SDM in
+%the kx-domain
 %
 %   Usage: D = driving_function_mono_sdm_kx_pw(kx,nk,f,conf)
 %
@@ -12,10 +12,6 @@ function D = driving_function_mono_sdm_kx_pw(kx,nk,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_KX_PW(kx,nk,f,conf) returns SDM driving signals
-%   for the given secondary sources, the virtual plane wave direction and the
-%   frequency f. The driving signal is calculated in the kx domain.
 %
 %   See also: driving_function_mono_sdm_kx, sound_field_mono_sdm_kx
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_ls.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_ls.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_sdm_ls(x0,nk,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_LS returns the driving signal D for a line source in
-%SDM
+%DRIVING_FUNCTION_MONO_SDM_LS driving signal for a line source in SDM
 %
 %   Usage: D = driving_function_mono_sdm_ls(x0,nk,f,conf)
 %
@@ -12,10 +11,6 @@ function D = driving_function_mono_sdm_ls(x0,nk,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_LS(x0,nk,f,conf) returns SDM driving signals
-%   for the given secondary sources, the virtual line source position and the
-%   frequency f.
 %
 %   See also: driving_function_mono_sdm
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_ps.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_sdm_ps(x0,nk,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_PS returns the driving signal D for a point source in
-%SDM
+%DRIVING_FUNCTION_MONO_SDM_PS driving signal for a point source in SDM
 %
 %   Usage: D = driving_function_mono_sdm_ps(x0,nk,f,conf)
 %
@@ -12,10 +11,6 @@ function D = driving_function_mono_sdm_ps(x0,nk,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_PS(x0,nk,f,conf) returns SDM driving signals
-%   for the given secondary sources, the virtual point source position and the
-%   frequency f.
 %
 %   See also: driving_function_mono_sdm
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_pw.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_sdm_pw(x0,nk,f,conf)
-%DRIVING_FUNCTION_MONO_SDM_PW returns the driving signal D for a plane wave in
-%SDM
+%DRIVING_FUNCTION_MONO_SDM_PW driving signal for a plane wave in SDM
 %
 %   Usage: D = driving_function_mono_sdm_pw(x0,nk,f,conf)
 %
@@ -12,10 +11,6 @@ function D = driving_function_mono_sdm_pw(x0,nk,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_SDM_PW(x0,nk,f,conf) returns SDM driving signals
-%   for the given secondary sources, the virtual plane wave direction and the
-%   frequency f.
 %
 %   See also: driving_function_mono_wfs, driving_function_imp_wfs_ps
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_wfs_fs(x0,nx0,xs,f,conf)
-%DRIVING_FUNCTION_MONO_WFS_FS returns the driving signal D for a focused source
-%in WFS
+%DRIVING_FUNCTION_MONO_WFS_FS driving signal for a focused source in WFS
 %
 %   Usage: D = driving_function_mono_wfs_fs(x0,nx0,xs,f,[conf])
 %

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ls.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ls.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_wfs_ls(x0,nx0,xs,f,conf)
-%DRIVING_FUNCTION_MONO_WFS_LS returns the driving signal D for a line source in
-%WFS
+%DRIVING_FUNCTION_MONO_WFS_LS driving signal for a line source in WFS
 %
 %   Usage: D = driving_function_mono_wfs_ls(x0,nx0,xs,nxs,f,conf)
 %

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ps.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_wfs_ps(x0,nx0,xs,f,conf)
-%DRIVING_FUNCTION_MONO_WFS_PS returns the driving signal D for a point source in
-%WFS
+%DRIVING_FUNCTION_MONO_WFS_PS driving signal for a point source in WFS
 %
 %   Usage: D = driving_function_mono_wfs_ps(x0,nx0,xs,f,conf)
 %
@@ -13,10 +12,6 @@ function D = driving_function_mono_wfs_ps(x0,nx0,xs,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_WFS_PS(x0,xs,f,src,conf) returns WFS driving signals
-%   for the given secondary sources, the virtual point source position and the
-%   frequency f.
 %
 %   See also: driving_function_mono_wfs, driving_function_imp_wfs_ps
 %

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_pw.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_wfs_pw(x0,nx0,nk,f,conf)
-%DRIVING_FUNCTION_MONO_WFS_PW returns the driving signal D for a plane wave in
-%WFS
+%DRIVING_FUNCTION_MONO_WFS_PW driving signal for a plane wave in WFS
 %
 %   Usage: D = driving_function_mono_wfs_pw(x0,nx0,nk,f,conf)
 %
@@ -13,10 +12,6 @@ function D = driving_function_mono_wfs_pw(x0,nx0,nk,f,conf)
 %
 %   Output parameters:
 %       D           - driving function signal [nx1]
-%
-%   DRIVING_FUNCTION_MONO_WFS_PW(x0,nx0,nk,f,conf) returns WFS driving signals
-%   for the given secondary sources, the virtual plane wave direction and the
-%   frequency f.
 %
 %   See also: driving_function_mono_wfs, driving_function_imp_wfs_ps
 %

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_pwd.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_pwd.m
@@ -1,6 +1,5 @@
 function D = driving_function_mono_wfs_pwd(x0,Ppwd,f,xq,conf)
-%DRIVING_FUNCTION_IMP_WFS_PWD returns the WFS driving signal for a plane wave 
-%expansion
+%DRIVING_FUNCTION_IMP_WFS_PWD driving signal for a plane wave expansion in WFS
 %
 %   Usage: D = driving_function_mono_wfs_pwd(x0,Ppwd,f,[xq],conf)
 %

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_vss.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_vss.m
@@ -1,6 +1,6 @@
 function D = driving_function_mono_wfs_vss(x0,xv,srcv,Dv,f,conf)
-%DRIVING_FUNCTION_MONO_WFS_VSS returns the driving signal D for a given set of
-%virtual secondary sources and their driving signals
+%DRIVING_FUNCTION_MONO_WFS_VSS driving signal for a given set of virtual
+%secondary sources and their driving signals
 %
 %   Usage: D = driving_function_mono_wfs_vss(x0,xv,srcv,Dv,f,conf)
 %

--- a/SFS_monochromatic/greens_function_mono.m
+++ b/SFS_monochromatic/greens_function_mono.m
@@ -1,5 +1,5 @@
 function G = greens_function_mono(x,y,z,xs,src,f,conf)
-%GREENS_FUNCTION_MONO returns a Green's function in the frequency domain
+%GREENS_FUNCTION_MONO Green's function in the frequency domain
 %
 %   Usage: G = greens_function_mono(x,y,z,xs,src,f,conf)
 %

--- a/SFS_monochromatic/movie_sound_field_mono_wfs.m
+++ b/SFS_monochromatic/movie_sound_field_mono_wfs.m
@@ -1,5 +1,5 @@
 function movie_sound_field_mono_wfs(X,Y,Z,xs,src,f,outfile,conf)
-%MOVIE_SOUND_FIELD_MONO_WFS generates movie a WFS sound field
+%MOVIE_SOUND_FIELD_MONO_WFS movie of a WFS sound field
 %
 %   Usage: movie_sound_field_mono_wfs(X,Y,Z,xs,src,f,outfile,conf)
 %

--- a/SFS_monochromatic/sound_field_mono.m
+++ b/SFS_monochromatic/sound_field_mono.m
@@ -1,6 +1,6 @@
 function varargout = sound_field_mono(X,Y,Z,x0,src,D,f,conf)
-%SOUND_FIELD_MONO simulates a monofrequent sound field for the given driving
-%signals and secondary sources
+%SOUND_FIELD_MONO mono-frequent sound field for the given driving signals and
+%secondary sources
 %
 %   Usage: [P,x,y,z] = sound_field_mono(X,Y,Z,x0,src,D,f,conf)
 %

--- a/SFS_monochromatic/sound_field_mono_line_source.m
+++ b/SFS_monochromatic/sound_field_mono_line_source.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_mono_line_source(X,Y,Z,xs,f,conf)
-%SOUND_FIELD_MONO_LINE_SOURCE simulates a sound field for a line source
+%SOUND_FIELD_MONO_LINE_SOURCE sound field for a line source
 %
 %   Usage: [P,x,y,z] = sound_field_mono_line_source(X,Y,Z,xs,f,conf)
 %

--- a/SFS_monochromatic/sound_field_mono_localwfs_sbl.m
+++ b/SFS_monochromatic/sound_field_mono_localwfs_sbl.m
@@ -1,5 +1,6 @@
 function varargout = sound_field_mono_localwfs_sbl(X,Y,Z,xs,src,f,conf)
-%SOUND_FIELD_MONO_LOCALWFS_SBL returns the sound field local WFS
+%SOUND_FIELD_MONO_LOCALWFS_SBL sound field of local WFS using spatial bandwith
+%limitation
 %
 %   Usage: [P,x,y,z,x0] = sound_field_mono_localwfs_sbl(X,Y,Z,xs,src,f,conf)
 %
@@ -22,9 +23,9 @@ function varargout = sound_field_mono_localwfs_sbl(X,Y,Z,xs,src,f,conf)
 %       z           - corresponding z values / m
 %       x0          - secondary sources / m
 %
-%   SOUND_FIELD_MONO_LOCALWFS_SBL(X,Y,Z,xs,src,f,conf) simulates a sound field
-%   of the given source type (src) synthesized with local wave field synthesis 
-%   for the frequency f.
+%   SOUND_FIELD_MONO_LOCALWFS_SBL(X,Y,Z,xs,src,f,conf) simulates a monochromatic
+%   sound field of the given source type (src) synthesized with local wave field
+%   synthesis using spatial bandwidth limitation for the frequency f.
 %
 %   To plot the result use:
 %   plot_sound_field(P,X,Y,Z,x0,conf);

--- a/SFS_monochromatic/sound_field_mono_localwfs_vss.m
+++ b/SFS_monochromatic/sound_field_mono_localwfs_vss.m
@@ -1,5 +1,6 @@
 function varargout = sound_field_mono_localwfs_vss(X,Y,Z,xs,src,f,conf)
-%SOUND_FIELD_MONO_LOCALWFS_VSS simulates a sound field for local WFS
+%SOUND_FIELD_MONO_LOCALWFS_VSS sound field of local WFS using virtual secondary
+%sources
 %
 %   Usage: [P,x,y,z,x0] = sound_field_mono_localwfs_vss(X,Y,Z,xs,src,f,conf)
 %
@@ -23,9 +24,9 @@ function varargout = sound_field_mono_localwfs_vss(X,Y,Z,xs,src,f,conf)
 %       z           - corresponding z values / m
 %       x0          - active secondary sources / m
 %
-%   SOUND_FIELD_MONO_LOCALWFS_VSS(X,Y,Z,xs,src,f,conf) simulates a
-%   monochromatic sound field for the given source type (src) synthesized with
-%   local wave field synthesis.
+%   SOUND_FIELD_MONO_LOCALWFS_VSS(X,Y,Z,xs,src,f,conf) simulates a monochromatic
+%   sound field of the given source type (src) synthesized with local wave field
+%   synthesis using virtual secondary sources for the frequency f.
 %
 %   To plot the result use:
 %   plot_sound_field(P,X,Y,Z,x0,conf);

--- a/SFS_monochromatic/sound_field_mono_nfchoa.m
+++ b/SFS_monochromatic/sound_field_mono_nfchoa.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_mono_nfchoa(X,Y,Z,xs,src,f,conf)
-%SOUND_FIELD_MONO_NFCHOA simulates a sound field for NFC-HOA
+%SOUND_FIELD_MONO_NFCHOA sound field for NFC-HOA
 %
 %   Usage: [P,x,y,z,x0] = sound_field_mono_nfchoa(X,Y,Z,xs,src,f,conf)
 %
@@ -24,7 +24,7 @@ function varargout = sound_field_mono_nfchoa(X,Y,Z,xs,src,f,conf)
 %
 %   SOUND_FIELD_MONO_NFCHOA(X,Y,Z,xs,src,f,conf) simulates a monochromatic sound
 %   field of the given source type (src) synthesized with near-field compensated
-%   higher order Ambisonics.
+%   higher order Ambisonics for the frequency f.
 %
 %   To plot the result use:
 %   plot_sound_field(P,X,Y,Z,x0,conf);

--- a/SFS_monochromatic/sound_field_mono_plane_wave.m
+++ b/SFS_monochromatic/sound_field_mono_plane_wave.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_mono_plane_wave(X,Y,Z,xs,f,conf)
-%SOUND_FIELD_MONO_PLANE_WAVE simulates a sound field of a plane wave
+%SOUND_FIELD_MONO_PLANE_WAVE sound field of a plane wave
 %
 %   Usage: [P,x,y,z] = sound_field_mono_plane_wave(X,Y,Z,xs,f,conf)
 %
@@ -18,7 +18,7 @@ function varargout = sound_field_mono_plane_wave(X,Y,Z,xs,f,conf)
 %       z           - corresponding z values / m
 %
 %   SOUND_FIELD_MONO_PLANE_WAVE(X,Y,Z,xs,f,conf) simulates a monochromatic sound
-%   field of a plane wave going in the direction xs.
+%   field of a plane wave going in the direction xs for the frequency f.
 %
 %   To plot the result use:
 %   plot_sound_field(P,X,Y,Z,conf);

--- a/SFS_monochromatic/sound_field_mono_point_source.m
+++ b/SFS_monochromatic/sound_field_mono_point_source.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_mono_point_source(X,Y,Z,xs,f,conf)
-%SOUND_FIELD_MONO_POINT_SOURCE simulates a sound field for a point source
+%SOUND_FIELD_MONO_POINT_SOURCE sound field for a point source
 %
 %   Usage: [P,x,y,z] = sound_field_mono_point_source(X,Y,Z,xs,f,conf)
 %
@@ -18,7 +18,7 @@ function varargout = sound_field_mono_point_source(X,Y,Z,xs,f,conf)
 %       z           - corresponding z values / m
 %
 %   SOUND_FIELD_MONO_POINT_SOURCE(X,Y,Z,xs,f,conf) simulates a monochromatic sound
-%   field of a point source positioned at xs.
+%   field of a point source positioned at xs for the frequency f.
 %
 %   To plot the result use:
 %   plot_sound_field(P,X,Y,Z,conf);

--- a/SFS_monochromatic/sound_field_mono_sdm.m
+++ b/SFS_monochromatic/sound_field_mono_sdm.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_mono_sdm(X,Y,Z,xs,src,f,conf)
-%SOUND_FIELD_MONO_SDM simulates a sound field for SDM
+%SOUND_FIELD_MONO_SDM sound field for SDM
 %
 %   Usage: [P,x,y,z,x0] = sound_field_mono_sdm(X,Y,Z,xs,src,f,conf)
 %
@@ -25,7 +25,7 @@ function varargout = sound_field_mono_sdm(X,Y,Z,xs,src,f,conf)
 %
 %   SOUND_FIELD_MONO_SDM(X,Y,Z,xs,src,f,conf) simulates a monochromatic sound
 %   field for the given source type (src) synthesized with the spectral devision
-%   method (SDM).
+%   method (SDM) for the frequency f.
 %
 %   To plot the result use:
 %   plot_sound_field(P,X,Y,Z,x0,conf);

--- a/SFS_monochromatic/sound_field_mono_sdm_kx.m
+++ b/SFS_monochromatic/sound_field_mono_sdm_kx.m
@@ -1,6 +1,5 @@
 function varargout = sound_field_mono_sdm_kx(X,Y,Z,xs,src,f,conf)
-%SOUND_FIELD_MONO_SDM_KX simulates the sound field of a given source for SDM
-%in the kx domain
+%SOUND_FIELD_MONO_SDM_KX sound field for SDM in the kx-domain
 %
 %   Usage: [P,x,y,z] = sound_field_mono_sdm_kx(X,Y,Z,xs,src,f,conf)
 %
@@ -25,9 +24,10 @@ function varargout = sound_field_mono_sdm_kx(X,Y,Z,xs,src,f,conf)
 %
 %   SOUND_FIELD_MONO_SDM_KX(X,Y,Z,xs,src,f,conf) simulates a monochromatic sound
 %   field of the given source type (src) synthesized with the spectral devision
-%   method (SDM). Note, that the linaer secondary sources are placed automatically
-%   on a line parrallel to the x-axis accordingly to conf.secondary_sources.center.
-%   The field can only be calculated in the xy-plane, meaning only Z=0 is allowed.
+%   method (SDM) for the frequency f. Note, that the linaer secondary sources
+%   are placed automatically on a line parrallel to the x-axis accordingly to
+%   conf.secondary_sources.center.  The field can only be calculated in the
+%   xy-plane, meaning only Z=0 is allowed.
 %
 %   To plot the result use:
 %   plot_sound_field(P,X,Y,Z,conf);

--- a/SFS_monochromatic/sound_field_mono_wfs.m
+++ b/SFS_monochromatic/sound_field_mono_wfs.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_mono_wfs(X,Y,Z,xs,src,f,conf)
-%SOUND_FIELD_MONO_WFS simulates a sound field for WFS
+%SOUND_FIELD_MONO_WFS sound field for WFS
 %
 %   Usage: [P,x,y,z,x0] = sound_field_mono_wfs(X,Y,Z,xs,src,f,conf)
 %
@@ -24,7 +24,8 @@ function varargout = sound_field_mono_wfs(X,Y,Z,xs,src,f,conf)
 %       x0          - active secondary sources / m
 %
 %   SOUND_FIELD_MONO_WFS(X,Y,Z,xs,src,f,conf) simulates a monochromatic sound
-%   field for the given source type (src) synthesized with wave field synthesis.
+%   field for the given source type (src) synthesized with wave field synthesis
+%   for the frequency f.
 %
 %   To plot the result use:
 %   plot_sound_field(P,X,Y,Z,x0,conf);

--- a/SFS_octave/db.m
+++ b/SFS_octave/db.m
@@ -1,5 +1,5 @@
 function sig = db(sig)
-%DB Convert to decibels.
+%DB convert to decibels
 %
 %   Usage: sig = db(sig)
 %

--- a/SFS_octave/rms.m
+++ b/SFS_octave/rms.m
@@ -1,5 +1,5 @@
 function level = rms(sig,dim)
-%RMS Root-mean square level.
+%RMS root-mean square level
 %
 %   Usage: level = rms(sig,[dim])
 %
@@ -9,9 +9,6 @@ function level = rms(sig,dim)
 %
 %   Output parameters:
 %       level - rms level
-%
-%   RMS(sig,dim) calculates the root mean square level along the given
-%   dimension. Dimension defaults to 1, if non is provided.
 %
 %   See also: db
 

--- a/SFS_plotting/draw_loudspeakers.m
+++ b/SFS_plotting/draw_loudspeakers.m
@@ -3,7 +3,7 @@ function draw_loudspeakers(x0,dimensions,conf)
 %
 %   Usage: draw_loudspeakers(x0,[dimensions],conf)
 %
-%   Input options:
+%   Input parameters:
 %       x0          - positions and directions of the loudspeakers / m
 %       dimensions  - dimension defining the plane in which the loudspeaker
 %                     symbol should be plotted. For example [1 1 0] corresponds

--- a/SFS_plotting/figsize.m
+++ b/SFS_plotting/figsize.m
@@ -1,9 +1,9 @@
 function figsize(x,y,unit)
-%FIGSIZE changes the size of a figure
+%FIGSIZE size of a figure
 %
 %   Usage: figsize(x,y,unit)
 %
-%   Input options:
+%   Input parameters:
 %       x,y         - x,y size of the figure
 %       unit        - unit in which the size is given, can be one of the
 %                     following: 'cm', 'px'

--- a/SFS_plotting/generate_movie.m
+++ b/SFS_plotting/generate_movie.m
@@ -1,5 +1,5 @@
 function generate_movie(outfile,directory,pattern)
-%GENERATE_MOVIE generates a movie from given png files
+%GENERATE_MOVIE movie from given png files
 %
 %   Usage: generate_movie(outfile,[[directory],pattern])
 %

--- a/SFS_plotting/gp_load.m
+++ b/SFS_plotting/gp_load.m
@@ -1,5 +1,5 @@
 function [x,y,header] = gp_load(file)
-%GP_LOAD load x,y from a text file
+%GP_LOAD loads x,y from a text file
 %
 %   Usage: [x,y,header] = gp_load(file)
 %

--- a/SFS_plotting/gp_save.m
+++ b/SFS_plotting/gp_save.m
@@ -1,5 +1,5 @@
 function gp_save(file,data,header)
-% GP_SAVE save x,y as a text file in a Gnuplot compatible format
+%GP_SAVE saves x,y as a text file in a Gnuplot compatible format
 %
 %   Usage: gp_save(file,data,[header])
 %
@@ -7,9 +7,6 @@ function gp_save(file,data,header)
 %       file    - filename of the data file
 %       data    - data matrix
 %       header  - header comment added before the data
-%
-%   GP_SAVE(file,data,header) saves the values data in a text file in a
-%   format useable by Gnuplot
 %
 %   See also: gp_save_matrix
 

--- a/SFS_plotting/gp_save_loudspeakers.m
+++ b/SFS_plotting/gp_save_loudspeakers.m
@@ -1,5 +1,5 @@
 function gp_save_loudspeakers(file,x0)
-% GP_SAVE_LOUDSPEAKERS save x0 as a text file in a Gnuplot compatible format
+%GP_SAVE_LOUDSPEAKERS saves x0 as a text file in a Gnuplot compatible format
 %
 %   Usage: gp_save_loudspeakers(file,x0)
 %

--- a/SFS_plotting/gp_save_matrix.m
+++ b/SFS_plotting/gp_save_matrix.m
@@ -1,5 +1,5 @@
 function gp_save_matrix(file,x,y,M)
-% GP_SAVE_MATRIX save x,y,M in the matrix binary format of Gnuplot
+%GP_SAVE_MATRIX saves x,y,M in the matrix binary format of Gnuplot
 %
 %   Usage: gp_save_matrix(file,x,y,M)
 %

--- a/SFS_plotting/norm_sound_field.m
+++ b/SFS_plotting/norm_sound_field.m
@@ -3,11 +3,11 @@ function P = norm_sound_field(P,conf)
 %
 %   Usage: P = norm_sound_field(P,conf)
 %
-%   Input options:
+%   Input parameters:
 %       P       - sound field
 %       conf    - configuration struct (see SFS_config)
 %
-%   Output options:
+%   Output parameters:
 %       P       - normalized sound field
 %
 %   NORM_SOUND_FIELD(P,conf) normalizes the given sound field P. This depends on

--- a/SFS_plotting/plot_sound_field.m
+++ b/SFS_plotting/plot_sound_field.m
@@ -1,5 +1,5 @@
 function plot_sound_field(P,X,Y,Z,x0,conf)
-%PLOT_SOUND_FIELD plot the given sound field
+%PLOT_SOUND_FIELD plots a sound field
 %
 %   Usage: plot_sound_field(P,X,Y,Z,[x0],conf)
 %

--- a/SFS_plotting/print_eps.m
+++ b/SFS_plotting/print_eps.m
@@ -3,10 +3,8 @@ function print_eps(outfile)
 %
 %   Usage: print_eps(outfile)
 %
-%   Input options:
+%   Input parameters:
 %       outfile     - file name to store the figure
-%
-%   PRINT_EPS(outfile) prints the figure as eps file.
 %
 %   See also: plot_sound_field, print_png
 

--- a/SFS_plotting/print_png.m
+++ b/SFS_plotting/print_png.m
@@ -3,10 +3,8 @@ function print_png(outfile)
 %
 %   Usage: print_png(outfile)
 %
-%   Input options:
+%   Input parameters:
 %       outfile     - file name to store the figure
-%
-%   PRINT_EPS(outfile) plots the last figure as an eps file to outfile.
 %
 %   See also: plot_sound_field, print_png
 

--- a/SFS_plotting/set_colorbar.m
+++ b/SFS_plotting/set_colorbar.m
@@ -3,7 +3,7 @@ function set_colorbar(conf)
 %
 %   Usage: set_colorbar(conf)
 %
-%   Input options:
+%   Input parameters:
 %       conf        - configuration struct (see SFS_config)
 %
 %   SET_COLORBAR(conf) draws a color bar on the figure and sets the map to the

--- a/SFS_plotting/set_colormap.m
+++ b/SFS_plotting/set_colormap.m
@@ -1,9 +1,9 @@
 function set_colormap(map)
-%SET_COLORMAP set the color of the color map
+%SET_COLORMAP sets the color of the color map
 %
 %   Usage: set_colormap(map)
 %
-%   Input options:
+%   Input parameters:
 %       map         - can be the real map (see help colormap) or one of the
 %                     following:
 %                       'default' - blue,white,red

--- a/SFS_plotting/set_font_size.m
+++ b/SFS_plotting/set_font_size.m
@@ -3,11 +3,8 @@ function set_font_size(fontsize)
 %
 %   Usage: set_font_size(fontsize)
 %
-%   Input options:
+%   Input parameters:
 %       fontsize   - font size
-%
-%   SET_FONT_SIZE(fontsize) sets the font size of the active figure to the
-%   given size.
 %
 %   See also: set_font_type, print_png
 

--- a/SFS_plotting/set_font_type.m
+++ b/SFS_plotting/set_font_type.m
@@ -3,10 +3,8 @@ function set_font_type(font)
 %
 %   Usage: set_font_type(font)
 %
-%   Input options:
+%   Input parameters:
 %       font   - font type name
-%
-%   SET_FONT_TYPE(font) sets the font of the active figure to the given type.
 %
 %   See also: set_font_size, print_png
 

--- a/SFS_ssr/ssr_brs.m
+++ b/SFS_ssr/ssr_brs.m
@@ -1,6 +1,5 @@
 function brs = ssr_brs(X,phi,x0,d,irs,conf)
-%SSR_BRS generates a binaural room scanning (BRS) set for use with the
-%SoundScape Renderer
+%SSR_BRS binaural room scanning (BRS) set for use with the SoundScape Renderer
 %
 %   Usage: brs = ssr_brs(X,phi,x0,d,irs,conf)
 %
@@ -13,8 +12,8 @@ function brs = ssr_brs(X,phi,x0,d,irs,conf)
 %       conf    - configuration struct (see SFS_config)
 %
 %   Output parameters:
-%       brs     - conf.N x 2*nangles matrix containing all impulse responses (2
-%                 channels) for every angle of the BRS set
+%       brs     - conf.N x 2*nangles matrix containing all impulse responses
+%                 (2 channels) for every angle of the BRS set
 %
 %   SSR_BRS(X,phi,x0,d,irs,conf) prepares a BRS set for the given secondary
 %   sources and its driving signals for the given listener position.

--- a/SFS_ssr/ssr_brs_nfchoa.m
+++ b/SFS_ssr/ssr_brs_nfchoa.m
@@ -1,6 +1,6 @@
 function [brs,delay] = ssr_brs_nfchoa(X,phi,xs,src,irs,conf)
-%SSR_BRS_NFCHOA generates a binaural room scanning (BRS) set for use with the
-%SoundScape Renderer
+%SSR_BRS_NFCHOA binaural room scanning (BRS) set for use with the SoundScape
+%Renderer
 %
 %   Usage: [brs,delay] = ssr_brs_nfchoa(X,phi,xs,src,irs,conf)
 %

--- a/SFS_ssr/ssr_brs_point_source.m
+++ b/SFS_ssr/ssr_brs_point_source.m
@@ -1,6 +1,6 @@
 function brs = ssr_brs_point_source(X,phi,xs,irs,conf)
-%SSR_BRS_POINT_SOURCE generates a binaural room scanning (BRS) set for use with
-%the SoundScape Renderer
+%SSR_BRS_POINT_SOURCE binaural room scanning (BRS) set for use with the
+%SoundScape Renderer
 %
 %   Usage: brs = ssr_brs_point_source(X,phi,xs,irs,conf)
 %

--- a/SFS_ssr/ssr_brs_wfs.m
+++ b/SFS_ssr/ssr_brs_wfs.m
@@ -1,6 +1,6 @@
 function [brs,delay] = ssr_brs_wfs(X,phi,xs,src,irs,conf)
-%SSR_BRS_WFS generates a binaural room scanning (BRS) set for use with the
-%SoundScape Renderer
+%SSR_BRS_WFS binaural room scanning (BRS) set for use with the SoundScape
+%Renderer
 %
 %   Usage: [brs,delay] = ssr_brs_wfs(X,phi,xs,src,irs,conf)
 %

--- a/SFS_ssr/ssr_generic_nfchoa.m
+++ b/SFS_ssr/ssr_generic_nfchoa.m
@@ -1,6 +1,6 @@
 function ir = ssr_generic_nfchoa(xs,src,conf)
-%SSR_GENERIC_NFCHOA generate an impulse response for the generic renderer of the
-%SoundScape Renderer
+%SSR_GENERIC_NFCHOA impulse response for the generic renderer of the SoundScape
+%Renderer
 %
 %   Usage: ir = ssr_generic_nfchoa(xs,src,conf)
 %
@@ -16,12 +16,11 @@ function ir = ssr_generic_nfchoa(xs,src,conf)
 %
 %   GENERIC_NFCHOA(xs,src,conf) calculates an impulse response for a virtual
 %   source at xs for the loudspeakers of a NFC-HOA array. Every loudspeaker of
-%   the array is represented by one column in the impulse response.
-%   For the generic renderer it is of importance to know what position the first
+%   the array is represented by one column in the impulse response.  For the
+%   generic renderer it is of importance to know what position the first
 %   loudspeaker of your array will have. For example, the included circular
 %   array has its first loudspeaker at phi=0deg which is on the x-axis. If you
 %   have another setup you have to provide it with conf.secondary_sources.x0.
-%
 %
 %   See also: generic_wfs, brs_nfchoa, driving_function_imp_nfchoa
 

--- a/SFS_ssr/ssr_generic_wfs.m
+++ b/SFS_ssr/ssr_generic_wfs.m
@@ -1,6 +1,6 @@
 function ir = ssr_generic_wfs(xs,src,conf)
-%SSR_GENRIC_WFS generates an impulse response for the generic renderer of the
-%SoundScape Renderer
+%SSR_GENRIC_WFS impulse response for the generic renderer of the SoundScape
+%Renderer
 %
 %   Usage: ir = ssr_generic_wfs(xs,src,conf)
 %
@@ -22,7 +22,7 @@ function ir = ssr_generic_wfs(xs,src,conf)
 %   array has its first loudspeaker at phi=0deg which is on the x-axis. If you
 %   have another setup you have to provide it with conf.secondary_sources.x0.
 %
-% See also: generic_nfchoa, brs_wfs, driving_function_imp_wfs
+%   See also: generic_nfchoa, brs_wfs, driving_function_imp_wfs
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_time_domain/circexp_imp/circexp_imp_ps.m
+++ b/SFS_time_domain/circexp_imp/circexp_imp_ps.m
@@ -1,5 +1,5 @@
 function [pm,delay_offset] = circexp_imp_ps(xs,Nce,xq,fhp,conf)
-%CIRCEXP_IMP_PS calculates the circular basis expansion of a point source
+%CIRCEXP_IMP_PS circular basis expansion of a point source in temporal domain
 %
 %   Usage: [pm,delay_offset] = circexp_imp_ps(xs,Nce,xq,[fhp],conf)
 %
@@ -14,9 +14,6 @@ function [pm,delay_offset] = circexp_imp_ps(xs,Nce,xq,fhp,conf)
 %       pm            - regular circular expansion coefficients in time domain
 %                       for m = 0:Nce, [conf.N x Nce+1]
 %       delay_offset  - additional added delay, so you can correct it
-%
-%   CIRCEXP_IMP_PS(xs,Nce,xq,fhp,conf) returns the circular basis expansion of
-%   a point source.
 %
 %   See also: circexp_imp_pw
 

--- a/SFS_time_domain/circexp_imp/circexp_imp_pw.m
+++ b/SFS_time_domain/circexp_imp/circexp_imp_pw.m
@@ -1,5 +1,5 @@
 function [pm,delay_offset] = circexp_imp_pw(npw,Nce,xq,conf)
-%CIRCEXP_IMP_PW calculates the circular basis expansion of a plane wave
+%CIRCEXP_IMP_PW circular basis expansion of a plane wave in temporal domain
 %
 %   Usage: [pm,delay_offset] = circexp_imp_pw(npw,Nce,xq,conf)
 %
@@ -13,9 +13,6 @@ function [pm,delay_offset] = circexp_imp_pw(npw,Nce,xq,conf)
 %       pm            - regular circular expansion coefficients in time domain
 %                       for m = 0:Nce, [conf.N x Nce+1]
 %       delay_offset  - additional added delay, so you can correct it
-%
-%   CIRCEXP_IMP_PW(npw,Nce,xq,conf) returns the circular basis expansion of
-%   a plane wave.
 %
 %   See also: circexp_imp_ps
 

--- a/SFS_time_domain/dirac_imp.m
+++ b/SFS_time_domain/dirac_imp.m
@@ -1,12 +1,10 @@
 function pulse = dirac_imp()
-%DIRAC_IMP returns a pulse as stimulus for the imp driving functions
+%DIRAC_IMP returns a 1 sample long dirac pulse
 %
 %   Usage: pulse = dirac_imp()
 %
 %   Output parameters:
 %       pulse    - short pulse signal
-%
-%   DIRAC_IMP() returns a 1 sample long dirac pulse.
 %
 %   See also: hann_window, driving_function_imp_wfs, driving_function_imp_nfchoa
 

--- a/SFS_time_domain/driving_function_imp_localwfs_sbl.m
+++ b/SFS_time_domain/driving_function_imp_localwfs_sbl.m
@@ -1,6 +1,6 @@
 function [d,delay_offset] = driving_function_imp_localwfs_sbl(x0,xs,src,conf)
-%DRIVING_FUNCTION_IMP_LOCALWFS_SBL returns the driving signal for local WFS
-%using spatial bandwidth limitation
+%DRIVING_FUNCTION_IMP_LOCALWFS_SBL driving signal for local WFS using spatial
+%bandwidth limitation
 %
 %   Usage: [d,delay_offset] = driving_function_imp_localwfs_sbl(x0,xs,src,conf)
 %

--- a/SFS_time_domain/driving_function_imp_localwfs_vss.m
+++ b/SFS_time_domain/driving_function_imp_localwfs_vss.m
@@ -1,8 +1,9 @@
 function [d,x0,xv,idx,delay_offset] = driving_function_imp_localwfs_vss(x0,xs,src,conf)
-%DRIVING_FUNCTION_IMP_LOCALWFS_VSS returns the driving signal d for local WFS
-%using focused sources as virtual secondary sources
+%DRIVING_FUNCTION_IMP_LOCALWFS_VSS driving signal for local WFS using focused
+%sources as virtual secondary sources
 %
-%   Usage: [d,x0,xv,idx,delay_offset] = driving_function_imp_localwfs_vss(x0,xs,src,conf)
+%   Usage: [d,x0,xv,idx,delay_offset] =
+%               driving_function_imp_localwfs_vss(x0,xs,src,conf)
 %
 %   Input parameters:
 %       x0          - position and direction of the secondary source / m [nx7]

--- a/SFS_time_domain/driving_function_imp_nfchoa.m
+++ b/SFS_time_domain/driving_function_imp_nfchoa.m
@@ -1,5 +1,5 @@
 function [d,dm,delay_offset] = driving_function_imp_nfchoa(x0,xs,src,conf)
-%DRIVING_FUNCTION_IMP_NFCHOA calculates the NFC-HOA driving function
+%DRIVING_FUNCTION_IMP_NFCHOA driving signal for NFC-HOA
 %
 %   Usage: [d,dm,delay_offset] = driving_function_imp_nfchoa(x0,xs,src,conf)
 %
@@ -17,10 +17,6 @@ function [d,dm,delay_offset] = driving_function_imp_nfchoa(x0,xs,src,conf)
 %       dm           - matrix of driving funtion in spherical/circular domain
 %                      [NxM]
 %       delay_offset - delay add by driving function / s
-%
-%   DRIVING_FUNCTION_IMP_NFCHOA(x0,xs,src,conf) returns the
-%   driving function of NFC-HOA for the given source type and position,
-%   and loudspeaker positions.
 %
 %   See also: driving_function_imp_nfchoa_ps, sound_field_imp_nfchoa
 %

--- a/SFS_time_domain/driving_function_imp_wfs.m
+++ b/SFS_time_domain/driving_function_imp_wfs.m
@@ -1,5 +1,5 @@
 function [d,delay,weight,delay_offset] = driving_function_imp_wfs(x0,xs,src,conf)
-%DRIVING_FUNCTION_IMP_WFS_25D calculates the WFS weighting and delaying
+%DRIVING_FUNCTION_IMP_WFS driving signal for WFS
 %
 %   Usage: [d,delay,weight,delay_offset] = ...
 %              driving_function_imp_wfs(x0,xs,src,conf)

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_ps.m
@@ -1,6 +1,6 @@
 function [d,delay_offset] = driving_function_imp_localwfs_sbl_ps(x0,xs,conf)
-%DRIVING_FUNCTION_IMP_LOCALWFS_SBL_PS returns the driving signal for a point 
-%source using local WFS with spatial bandwidth limitation
+%DRIVING_FUNCTION_IMP_LOCALWFS_SBL_PS driving signal for a point source using
+%local WFS with spatial bandwidth limitation
 %
 %   Usage: [d,delay_offset] = driving_function_imp_localwfs_sbl_ps(x0,xs,conf)
 %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_pw.m
@@ -1,6 +1,6 @@
 function [d,delay_offset] = driving_function_imp_localwfs_sbl_pw(x0,nk,conf)
-%DRIVING_FUNCTION_IMP_LOCALWFS_SBL_PW returns the driving signal for a plane
-%wave using local WFS with spatial bandwidth limitation
+%DRIVING_FUNCTION_IMP_LOCALWFS_SBL_PW driving signal for a plane wave using local
+%WFS with spatial bandwidth limitation
 %
 %   Usage: [d,delay_offset] = driving_function_imp_localwfs_sbl_pw(x0,nk,conf)
 %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_fs.m
@@ -1,6 +1,6 @@
 function [sos,g] = driving_function_imp_nfchoa_fs(N,R,r,conf)
-%DRIVING_FUNCTION_IMP_NFCHOA_FS calculates the second-order section
-%representation for a virtual focused source in NFC-HOA
+%DRIVING_FUNCTION_IMP_NFCHOA_FS second-order section representation for a
+%focused source in NFC-HOA
 %
 %   Usage: sos = driving_function_imp_nfchoa_fs(N,R,r,conf)
 %
@@ -14,11 +14,8 @@ function [sos,g] = driving_function_imp_nfchoa_fs(N,R,r,conf)
 %       sos     - second-order section representation
 %       g       - scalar gain factor
 %
-%   DRIVING_FUNCTION_IMP_NFCHOA_FS(N,R,r,conf) returns the second-order section
-%   representation for the NFC-HOA driving function for a virtual focused source
-%   as source model.
-%
-%   See also: sound_field_imp, sound_field_imp_nfchoa, driving_function_imp_nfchoa
+%   See also: sound_field_imp, sound_field_imp_nfchoa,
+%       driving_function_imp_nfchoa
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ls.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ls.m
@@ -1,6 +1,6 @@
 function [sos,g] = driving_function_imp_nfchoa_ls(N,R,r,conf)
-%DRIVING_FUNCTION_IMP_NFCHOA_LS calculates the second-order section
-%representation for a virtual line source in NFC-HOA
+%DRIVING_FUNCTION_IMP_NFCHOA_LS second-order section representation for a
+%line source in NFC-HOA
 %
 %   Usage: sos = driving_function_imp_nfchoa_ls(N,R,r,conf)
 %
@@ -14,11 +14,8 @@ function [sos,g] = driving_function_imp_nfchoa_ls(N,R,r,conf)
 %       sos     - second-order section representation
 %       g       - scalar gain factor
 %
-%   DRIVING_FUNCTION_IMP_NFCHOA_LS(N,R,r,conf) returns the second-order section
-%   representation for the NFC-HOA driving function for a virtual line source
-%   as source model.
-%
-%   See also: sound_field_imp, sound_field_imp_nfchoa, driving_function_imp_nfchoa
+%   See also: sound_field_imp, sound_field_imp_nfchoa,
+%       driving_function_imp_nfchoa
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
@@ -1,6 +1,6 @@
 function [sos,g] = driving_function_imp_nfchoa_ps(N,R,r,conf)
-%DRIVING_FUNCTION_IMP_NFCHOA_PS calculates the second-order section
-%representation for a virtual point source in NFC-HOA
+%DRIVING_FUNCTION_IMP_NFCHOA_PS second-order section representation for a
+%point source in NFC-HOA
 %
 %   Usage: sos = driving_function_imp_nfchoa_ps(N,R,r,conf)
 %
@@ -14,11 +14,8 @@ function [sos,g] = driving_function_imp_nfchoa_ps(N,R,r,conf)
 %       sos     - second-order section representation
 %       g       - scalar gain factor
 %
-%   DRIVING_FUNCTION_IMP_NFCHOA_PS(N,R,r,conf) returns the second-order section
-%   representation for the NFC-HOA driving function for a virtual point source
-%   as source model.
-%
-%   See also: sound_field_imp, sound_field_imp_nfchoa, driving_function_imp_nfchoa
+%   See also: sound_field_imp, sound_field_imp_nfchoa,
+%       driving_function_imp_nfchoa
 %
 %   References:
 %       Spors, Kuscher, Ahrens (2011) - "Efficient realization of model-based

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
@@ -1,6 +1,6 @@
 function [sos,g] = driving_function_imp_nfchoa_pw(N,R,conf)
-%DRIVING_FUNCTION_IMP_NFCHOA_PW calculates the second-order section
-%representation for a virtual plane wave in NFC-HOA
+%DRIVING_FUNCTION_IMP_NFCHOA_PW second-order section representation for a
+%plane wave in NFC-HOA
 %
 %   Usage: sos = driving_function_imp_nfchoa_pw(N,R,conf)
 %
@@ -13,11 +13,8 @@ function [sos,g] = driving_function_imp_nfchoa_pw(N,R,conf)
 %       sos     - second-order section representation
 %       g       - scalar gain factor
 %
-%   DRIVING_FUNCTION_IMP_NFCHOA_PW(N,R,conf) returns the second-order section
-%   representation for the NFC-HOA driving function for a virtual plane wave
-%   as source model.
-%
-%   See also: sound_field_imp, sound_field_imp_nfchoa, driving_function_imp_nfchoa
+%   See also: sound_field_imp, sound_field_imp_nfchoa,
+%       driving_function_imp_nfchoa
 %
 %   References:
 %       Spors, Kuscher, Ahrens (2011) - "Efficient realization of model-based

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
@@ -1,6 +1,5 @@
 function [delay,weight] = driving_function_imp_wfs_fs(x0,nx0,xs,conf)
-%DRIVING_FUNCTION_IMP_WFS_FS calculates the WFS weighting and delaying for a
-%focused source as source model
+%DRIVING_FUNCTION_IMP_WFS_FS weights and delays for a focused source in WFS
 %
 %   Usage: [delay,weight] = driving_function_imp_wfs_fs(x0,nx0,xs,conf)
 %
@@ -13,9 +12,6 @@ function [delay,weight] = driving_function_imp_wfs_fs(x0,nx0,xs,conf)
 %   Output parameters:
 %       delay   - delay of the driving function / s
 %       weight  - weight (amplitude) of the driving function
-%
-%   DRIVING_FUNCTION_IMP_WFS_FS(x0,nx0,xs,conf) returns delays and weights for
-%   the WFS driving function for a focused source as source model.
 %
 %   See also: sound_field_imp, sound_field_imp_wfs, driving_function_mono_wfs_fs
 %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ls.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ls.m
@@ -1,6 +1,5 @@
 function [delay,weight] = driving_function_imp_wfs_ls(x0,nx0,xs,conf)
-%DRIVING_FUNCTION_IMP_WFS_LS calculates the WFS weighting and delaying for a
-%line source as source model
+%DRIVING_FUNCTION_IMP_WFS_LS weights and delays for a line source in WFS
 %
 %   Usage: [delay,weight] = driving_function_imp_wfs_ls(x0,nx0,xs,conf)
 %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
@@ -1,6 +1,5 @@
 function [delay,weight] = driving_function_imp_wfs_ps(x0,nx0,xs,conf)
-%DRIVING_FUNCTION_IMP_WFS_PS calculates the WFS weighting and delaying for a
-%point source as source model
+%DRIVING_FUNCTION_IMP_WFS_PS weights and delays for a point source in WFS
 %
 %   Usage: [delay,weight] = driving_function_imp_wfs_ps(x0,nx0,xs,conf)
 %
@@ -13,9 +12,6 @@ function [delay,weight] = driving_function_imp_wfs_ps(x0,nx0,xs,conf)
 %   Output parameters:
 %       delay   - delay of the driving function / s
 %       weight  - weight (amplitude) of the driving function
-%
-%   DRIVING_FUNCTION_IMP_WFS_PS(x0,nx0,xs,conf) returns delays and weights for
-%   the WFS driving function for a point source as source model.
 %
 %   See also: sound_field_imp, sound_field_imp_wfs, driving_function_mono_wfs_ps
 %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_pw.m
@@ -1,6 +1,5 @@
 function [delay,weight] = driving_function_imp_wfs_pw(x0,nx0,nk,conf)
-%DRIVING_FUNCTION_IMP_WFS_PW calculates the WFS weighting and delaying for a
-%plane wave as source model
+%DRIVING_FUNCTION_IMP_WFS_PW weights and delays for a plane wave in WFS
 %
 %   Usage: [delay,weight] = driving_function_imp_wfs_pw(x0,nx0,nk,conf);
 %
@@ -13,9 +12,6 @@ function [delay,weight] = driving_function_imp_wfs_pw(x0,nx0,nk,conf)
 %   Output parameters:
 %       delay   - delay of the driving function / s
 %       weight  - weight (amplitude) of the driving function
-%
-%   DRIVING_FUNCTION_IMP_WFS_PW(x0,nx0,nk,conf) returns delays and weights for
-%   the WFS driving function for plane wave as source model.
 %
 %   See also: sound_field_imp, sound_field_imp_wfs, driving_function_mono_wfs_pw
 %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_pwd.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_pwd.m
@@ -1,6 +1,5 @@
 function [d,delay_offset] = driving_function_imp_wfs_pwd(x0,ppwd,xq,conf)
-%DRIVING_FUNCTION_IMP_WFS_PWD returns the WFS driving signal for a plane wave 
-%expansion
+%DRIVING_FUNCTION_IMP_WFS_PWD driving signal for a plane wave expansion in WFS
 %
 %   Usage: [d,delay_offset] = driving_function_imp_wfs_pwd(x0,ppwd,[xq],conf)
 %

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_vss.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_vss.m
@@ -1,5 +1,5 @@
 function [d,delay_offset] = driving_function_imp_wfs_vss(x0,xv,srcv,dv,conf)
-%DRIVING_FUNCTION_IMP_WFS_VSS returns the driving signal d for a given set of
+%DRIVING_FUNCTION_IMP_WFS_VSS driving signal for a given set of
 %virtual secondary sources and their corresponding driving signals
 %
 %   Usage: d = driving_function_imp_wfs_vss(x0,dv,xv,srcv,conf)

--- a/SFS_time_domain/greens_function_imp.m
+++ b/SFS_time_domain/greens_function_imp.m
@@ -1,5 +1,5 @@
 function [g,t] = greens_function_imp(x,y,z,xs,src,t,conf)
-%GREENS_FUNCTION_IMP returns a Green's function in the time domain
+%GREENS_FUNCTION_IMP Green's function in the time domain
 %
 %   Usage: [g,t] = greens_function_imp(x,y,z,xs,src,t,conf)
 %

--- a/SFS_time_domain/localwfs_findhpref.m
+++ b/SFS_time_domain/localwfs_findhpref.m
@@ -1,6 +1,5 @@
 function [hpreflow,hprefhigh] = localwfs_findhpref(X,phi,xs,src,conf)
-%LOCALWFS_FINDHPREF finds the frequency limits for the WFS pre-equalization
-%filter
+%LOCALWFS_FINDHPREF frequency limits for the WFS pre-equalization filter
 %
 %   Usage: [hpreflow, hprefhigh] = localwfs_findhpref(X,phi,xs,src,conf)
 %

--- a/SFS_time_domain/movie_sound_field_imp_wfs.m
+++ b/SFS_time_domain/movie_sound_field_imp_wfs.m
@@ -1,5 +1,5 @@
 function movie_sound_field_imp_wfs(X,Y,Z,xs,src,outfile,conf)
-%MOVIE_SOUND_FIELD_IMP_WFS generates movie a WFS sound field
+%MOVIE_SOUND_FIELD_IMP_WFS movie a WFS sound field
 %
 %   Usage: movie_sound_field_imp_wfs(X,Y,Z,xs,src,outfile,conf)
 %

--- a/SFS_time_domain/sound_field_imp.m
+++ b/SFS_time_domain/sound_field_imp.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_imp(X,Y,Z,x0,src,d,t,conf)
-%SOUND_FIELD_IMP returns the sound field in time domain
+%SOUND_FIELD_IMP sound field in time domain
 %
 %   Usage: [p,x,y,z] = sound_field_imp(X,Y,Z,x0,src,d,t,conf)
 %

--- a/SFS_time_domain/sound_field_imp_line_source.m
+++ b/SFS_time_domain/sound_field_imp_line_source.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_imp_line_source(X,Y,Z,xs,t,conf)
-%SOUND_FIELD_IMP_LINE_SOURCE simulates a sound field for a line source
+%SOUND_FIELD_IMP_LINE_SOURCE sound field of a line source
 %
 %   Usage: [p,x,y,z] = sound_field_imp_line_source(X,Y,Z,xs,t,conf)
 %

--- a/SFS_time_domain/sound_field_imp_localwfs_sbl.m
+++ b/SFS_time_domain/sound_field_imp_localwfs_sbl.m
@@ -1,6 +1,6 @@
 function varargout = sound_field_imp_localwfs_sbl(X,Y,Z,xs,src,t,conf)
-%SOUND_FIELD_IMP_LOCALWFS_SBL returns the sound field in time domain of an 
-%impulse
+%SOUND_FIELD_IMP_LOCALWFS_SBL sound field of local WFS using spatial bandwidth
+%limitation
 %
 %   Usage: [p,x,y,z,x0] = sound_field_imp_localwfs_sbl(X,Y,Z,xs,src,t,conf)
 %
@@ -23,9 +23,9 @@ function varargout = sound_field_imp_localwfs_sbl(X,Y,Z,xs,src,t,conf)
 %       z           - corresponding z values / m
 %       x0          - secondary sources / m
 %
-%   SOUND_FIELD_IMP_LOCALWFS(X,Y,Z,xs,src,t,conf) simulates a sound field of the
-%   given source type (src) synthesized with local wave field synthesis at the
-%   time t.
+%   SOUND_FIELD_IMP_LOCALWFS_SBL(X,Y,Z,xs,src,t,conf) simulates a sound field of
+%   the given source type (src) synthesized with local wave field synthesis
+%   using spatial bandwidth limitation at the time t.
 %
 %   To plot the result use:
 %   plot_sound_field(p,X,Y,Z,x0,conf);

--- a/SFS_time_domain/sound_field_imp_localwfs_vss.m
+++ b/SFS_time_domain/sound_field_imp_localwfs_vss.m
@@ -1,5 +1,6 @@
 function varargout = sound_field_imp_localwfs_vss(X,Y,Z,xs,src,t,conf)
-%SOUND_FIELD_IMP_LOCALWFS returns the sound field in time domain of an impulse
+%SOUND_FIELD_IMP_LOCALWFS sound field of local WFS using virtual secondary
+%sources
 %
 %   Usage: [p,x,y,z,x0] = sound_field_imp_localwfs_vss(X,Y,Z,xs,src,t,conf)
 %
@@ -23,8 +24,8 @@ function varargout = sound_field_imp_localwfs_vss(X,Y,Z,xs,src,t,conf)
 %       x0          - secondary sources / m
 %
 %   SOUND_FIELD_IMP_LOCALWFS(X,Y,Z,xs,src,t,conf) simulates a sound field of the
-%   given source type (src) synthesized with local wave field synthesis at the
-%   time t.
+%   given source type (src) synthesized with local wave field synthesis using
+%   focused sources as virtual secondary sources at the time t.
 %
 %   To plot the result use:
 %   plot_sound_field(p,X,Y,Z,x0,conf);

--- a/SFS_time_domain/sound_field_imp_nfchoa.m
+++ b/SFS_time_domain/sound_field_imp_nfchoa.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_imp_nfchoa(X,Y,Z,xs,src,t,conf)
-%SOUND_FIELD_IMP_NFCHOA returns the sound field in time domain for NFC-HOA
+%SOUND_FIELD_IMP_NFCHOA sound field for NFC-HOA
 %
 %   Usage: [p,x,y,z,x0] = sound_field_imp_nfchoa(X,Y,Z,xs,src,t,conf)
 %

--- a/SFS_time_domain/sound_field_imp_plane_wave.m
+++ b/SFS_time_domain/sound_field_imp_plane_wave.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_imp_plane_wave(X,Y,Z,xs,t,conf)
-%SOUND_FIELD_IMP_PLANE_WAVE simulates a sound field of a plane wave
+%SOUND_FIELD_IMP_PLANE_WAVE sound field of a plane wave
 %
 %   Usage: [p,x,y,z] = sound_field_imp_plane_wave(X,Y,Z,xs,t,conf)
 %

--- a/SFS_time_domain/sound_field_imp_point_source.m
+++ b/SFS_time_domain/sound_field_imp_point_source.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_imp_point_source(X,Y,Z,xs,t,conf)
-%SOUND_FIELD_IMP_POINT_SOURCE simulates a sound field for a point source
+%SOUND_FIELD_IMP_POINT_SOURCE sound field of a point source
 %
 %   Usage: [p,x,y,z] = sound_field_imp_point_source(X,Y,Z,xs,t,conf)
 %

--- a/SFS_time_domain/sound_field_imp_wfs.m
+++ b/SFS_time_domain/sound_field_imp_wfs.m
@@ -1,5 +1,5 @@
 function varargout = sound_field_imp_wfs(X,Y,Z,xs,src,t,conf)
-%SOUND_FIELD_IMP_WFS returns the sound field in time domain of an impulse
+%SOUND_FIELD_IMP_WFS sound field for WFS
 %
 %   Usage: [p,x,y,z,x0] = sound_field_imp_wfs(X,Y,Z,xs,src,t,conf)
 %

--- a/SFS_time_domain/wfs_fir_prefilter.m
+++ b/SFS_time_domain/wfs_fir_prefilter.m
@@ -1,5 +1,5 @@
 function hpre = wfs_fir_prefilter(conf)
-%WFS_FIR_PREFILTER creates a pre-equalization filter for WFS
+%WFS_FIR_PREFILTER pre-equalization filter for WFS
 %
 %   Usage: hpre = wfs_fir_prefilter(conf)
 %

--- a/SFS_time_domain/wfs_iir_prefilter.m
+++ b/SFS_time_domain/wfs_iir_prefilter.m
@@ -1,5 +1,5 @@
 function hpre = wfs_iir_prefilter(conf)
-%WFS_IIR_PREFILTER creates a minimum-phase IIR pre-equalization filter for WFS
+%WFS_IIR_PREFILTER minimum-phase IIR pre-equalization filter for WFS
 %
 %   Usage: hpre = wfs_iir_prefilter(conf)
 %

--- a/SFS_time_domain/wfs_preequalization.m
+++ b/SFS_time_domain/wfs_preequalization.m
@@ -1,5 +1,5 @@
 function [ir,delay] = wfs_preequalization(ir,conf)
-%WFS_PREEQUALIZATION applies a pre-equalization filter for WFS
+%WFS_PREEQUALIZATION applies the pre-equalization filter for WFS
 %
 %   Usage: ir = wfs_preequalization(ir,conf)
 %
@@ -10,10 +10,6 @@ function [ir,delay] = wfs_preequalization(ir,conf)
 %   Output parameters:
 %       ir      - signal with applied pre-equalization
 %       delay   - additional delay added by pre-equalization / s
-%
-%
-%   WFS_PREEQUALIZATION(ir,conf) applies the pre-equalization filter for
-%   Wave Field Synthesis to the given impulse response.
 %
 %   See also: wfs_fir_prefilter, wfs_iir_prefilter, driving_function_imp_wfs
 

--- a/validation/test_binaural_synthesis.m
+++ b/validation/test_binaural_synthesis.m
@@ -1,6 +1,5 @@
 function status = test_binaural_synthesis(modus)
-%TEST_BINAURAL_SYNTHESIS tests the correctness of the binaural synthesis
-%functions
+%TEST_BINAURAL_SYNTHESIS tests the binaural synthesis functions
 %
 %   Usage: status = test_binaural_synthesis(modus)
 %

--- a/validation/test_colormaps.m
+++ b/validation/test_colormaps.m
@@ -9,9 +9,6 @@ function status = test_colormaps(modus)
 %
 %   Output parameters:
 %       status  - true or false
-%
-%   TEST_COLORMAPS(modus) creates plots for monochromatic and time-domain sound
-%   field in dB with different colormaps.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_driving_functions.m
+++ b/validation/test_driving_functions.m
@@ -9,10 +9,6 @@ function status = test_driving_functions(modus)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   TEST_DRIVING_FUNCTIONS(MODUS) checks if the functions, that calculates
-%   the driving functions working correctly. Therefore different sound
-%   fields are simulated.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_driving_functions_imp_with_delay.m
+++ b/validation/test_driving_functions_imp_with_delay.m
@@ -10,11 +10,6 @@ function status = test_driving_functions_imp_with_delay(modus)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   TEST_DRIVING_FUNCTIONS_IMP_WITH_DELAY(MODUS) checks if the functions,
-%   that calculates the WFS driving functions in time-domain work correctly
-%   for the setting conf.t0 = 'source'.
-%   Therefore different sound fields are simulated.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_hrtf_extrapolation.m
+++ b/validation/test_hrtf_extrapolation.m
@@ -12,9 +12,6 @@ function status = test_hrtf_extrapolation(modus,hrtf_set)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   TEST_HRTF_EXTRAPOLATION(modus,hrtf_set) checks if the HRTF exrapolation works
-%   correctly.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_interpolation_methods.m
+++ b/validation/test_interpolation_methods.m
@@ -10,10 +10,6 @@ function status = test_interpolation_methods(modus)
 %
 %   Output parameters:
 %       status  - true or false
-%
-%   TEST_INTERPOLATION_METHODS(modus) demonstrates the different interpolation
-%   methods in the interpolate_ir function for shifted Dirac impulses and for
-%   HRIRs of different directions
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_interpolation_point_selection.m
+++ b/validation/test_interpolation_point_selection.m
@@ -10,10 +10,6 @@ function status = test_interpolation_point_selection(modus)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   TEST_SECONDARY_SOURCE_SELECTION(modus) checks if the grid point
-%   selection in findconvexcone for piecewise linear interpolation 
-%   is implemented correctly
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_localwfs_sbl.m
+++ b/validation/test_localwfs_sbl.m
@@ -9,10 +9,6 @@ function status = test_localwfs_sbl(modus)
 %
 %   Output parameters:
 %       status  - true or false
-%
-%   TEST_LOCALWFS_SBL(modus) checks if the monochromatic and time-domain 
-%   LWFS-SBL driving functions are working. Different sound fields are 
-%   calculated and plotted for visual inspection.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_localwfs_vss.m
+++ b/validation/test_localwfs_vss.m
@@ -9,10 +9,6 @@ function status = test_localwfs_vss(modus)
 %
 %   Output parameters:
 %       status  - true or false
-%
-%   TEST_LOCALWFS_VSS(modus) checks if the monochromatic and time-domain 
-%   LWFS-VSS driving functions are working. Different sound fields are 
-%   calculated and plotted for visual inspection.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_plotting.m
+++ b/validation/test_plotting.m
@@ -1,5 +1,5 @@
 function status = test_plotting(modus)
-%TEST_PLOT tests the correctness of test_plot()
+%TEST_PLOTTING tests the correctness of plot_sound_field()
 %
 %   Usage: status = test_plot(modus)
 %
@@ -9,9 +9,6 @@ function status = test_plotting(modus)
 %
 %   Output parameters:
 %       status  - true or false
-%
-%   TEST_PLOT(modus) creates plots for monochromatic and time-domain sound field
-%   with different dimensions and different grids.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_secondary_source_diameter.m
+++ b/validation/test_secondary_source_diameter.m
@@ -11,9 +11,6 @@ function status = test_secondary_source_diameter(modus)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   TEST_SECONDARY_SOURCE_DIAMTERE(modus) checks if the function, that
-%   calculates the secondary source diameter and center is working correctly.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_secondary_source_positions.m
+++ b/validation/test_secondary_source_positions.m
@@ -11,10 +11,6 @@ function status = test_secondary_source_positions(modus)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   TEST_SECONDARY_SOURCE_POSITIONS(modus) checks if the function, that
-%   calculates the secondary source positions and directions is working
-%   correctly.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_secondary_source_selection.m
+++ b/validation/test_secondary_source_selection.m
@@ -11,10 +11,6 @@ function status = test_secondary_source_selection(modus)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   TEST_SECONDARY_SOURCE_SELECTION(modus) checks if the secondary source
-%   selection needed for Wave Field Syntesis is implemented correctly in
-%   secondary_source_selection().
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_spectrum_signal_conversion.m
+++ b/validation/test_spectrum_signal_conversion.m
@@ -10,9 +10,6 @@ function status = test_spectrum_signal_conversion(modus)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   test_spectrum_signal_conversion(modus) checks if spectrum_from_signal() and
-%   signal_from_spectrum() works correctly.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_sphbesselh_zeros.m
+++ b/validation/test_sphbesselh_zeros.m
@@ -10,9 +10,6 @@ function status = test_sphbesselh_zeros(modus)
 %
 %   Output parameters:
 %       status  - true or false
-%
-%   TEST_SPHBESSELH_ZEROS(modus) creates plots showing the zeros of the
-%   spherical Hankel function as calculated by sphbesselh_zeros(order).
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *

--- a/validation/test_tapering_window.m
+++ b/validation/test_tapering_window.m
@@ -11,9 +11,6 @@ function status = test_tapering_window(modus)
 %
 %   Output parameters:
 %       status - true or false
-%
-%   TEST_TAPERING_WINDOW(modus) checks if the tapering window applied to the
-%   secondary sources in Wave Field Synthesis is working.
 
 %*****************************************************************************
 % The MIT License (MIT)                                                      *


### PR DESCRIPTION
This is a follow up on #172. Every function includes now a short first line and if needed a longer explanation later on.
In addition I switched `Input options:` to `Input parameters:` and `Output options:` to `Output parameters:` in a few functions where those occurred.