### PR TITLE
Logarithmic spacing for linear secondary source distributions

### DIFF
--- a/SFS_config.m
+++ b/SFS_config.m
@@ -255,7 +255,15 @@ conf.secondary_sources.corner_radius = 0.0; % / m
 % Or it could also be a SOFA struct or file name, in this case the positions are
 % extracted from the provided SOFA file.
 conf.secondary_sources.x0 = []; % / m
-% Grid for a spherical array. Available grids are:
+% Grid for linear and spherical arrays.
+% For linear arrays, available grids are:
+%   'equally_spaced_points' - constant distance between points
+%   'logarithmic'           - the spacing of the loudspeakers de-/increases 
+%                             exponentially the further they are away from
+%                             the center of the array. See also:
+%                             conf.secondary_sources.logspread
+%
+% For spherical arrays, available grids are:
 %   'equally_spaced_points' - Sphere with equal distance between grid points
 %   'gauss'                 - Gauss grid
 %   'fabian'                - grid of 3D HRTF measurement, available at
@@ -268,6 +276,10 @@ conf.secondary_sources.x0 = []; % / m
 % An exception are Gauss grids, which are available via 'gauss' and will be
 % calculated on the fly allowing very high number of secondary sources.
 conf.secondary_sources.grid = 'equally_spaced_points'; % string
+% Only for logarithmically sampled linear arrays: The ratio of between the 
+% spacing of the loudspeakers at the extremities of the array and the spacing
+% of the loudspeakers at the center of the array. 1.0 for equi-distant sampling.
+conf.secondary_sources.logspread = 1.0;
 
 
 %% ===== Wave Field Synthesis (WFS) ======================================

--- a/SFS_config.m
+++ b/SFS_config.m
@@ -255,14 +255,6 @@ conf.secondary_sources.corner_radius = 0.0; % / m
 % Or it could also be a SOFA struct or file name, in this case the positions are
 % extracted from the provided SOFA file.
 conf.secondary_sources.x0 = []; % / m
-% Grid for linear and spherical arrays.
-% For linear arrays, available grids are:
-%   'equally_spaced_points' - constant distance between points
-%   'logarithmic'           - the spacing of the loudspeakers de-/increases 
-%                             exponentially the further they are away from
-%                             the center of the array. See also:
-%                             conf.secondary_sources.logspread
-%
 % For spherical arrays, available grids are:
 %   'equally_spaced_points' - Sphere with equal distance between grid points
 %   'gauss'                 - Gauss grid
@@ -276,9 +268,10 @@ conf.secondary_sources.x0 = []; % / m
 % An exception are Gauss grids, which are available via 'gauss' and will be
 % calculated on the fly allowing very high number of secondary sources.
 conf.secondary_sources.grid = 'equally_spaced_points'; % string
-% Only for logarithmically sampled linear arrays: The ratio of between the 
-% spacing of the loudspeakers at the extremities of the array and the spacing
-% of the loudspeakers at the center of the array. 1.0 for equi-distant sampling.
+% Grid for linear arrays: Allows for logarithmically spaced arrays. It defines 
+% the ratio of the spacing of the loudspeakers at the extremities of the array 
+% and the spacing of the loudspeakers at the center of the array. 1.0 for
+% equi-distant sampling.
 conf.secondary_sources.logspread = 1.0;
 
 

--- a/SFS_general/secondary_source_positions.m
+++ b/SFS_general/secondary_source_positions.m
@@ -100,11 +100,11 @@ if strcmp('line',geometry) || strcmp('linear',geometry)
     %                       |
     %                       |
     %
-    x0 = zeros(nls,7);    
+    x0 = zeros(nls,7);
     x0(:,2) = X0(2);
     x0(:,3) = X0(3);
-    x0(:,5) = -1;  % Direction of secondary sources points in -y direction 
-    
+    x0(:,5) = -1;  % Direction of secondary sources points in -y direction
+
     u = linspace(-nls/2,nls/2,nls);
     du = nls/(nls-1);
     if isempty(conf.secondary_sources.grid) || ... 
@@ -112,26 +112,28 @@ if strcmp('line',geometry) || strcmp('linear',geometry)
         %          L
         % x0(u) = --- u + X0
         %         nls
-      
         x0(:,1) = X0(1) + u.*L/nls;
        	% Weight each secondary source by the inter-loudspeaker distance
         x0(:,7) = L./nls*du;  % dx = x0'(u)*du
     elseif strcmp(conf.secondary_sources.grid, 'logarithmic')
-        % 
+        % the distance between to loudspeakers increases exponentially
         %                  / |u|/u0  \
         % x0(u) = sgn(u).* |q      -1| + X0
         %                  \         / 
-        %
+        % with
         %  1/u0    x0(|u|+2) - x0(|u|+1) 
         % q     = ----------------------- = const.
         %           x0(|u|+1) - x0(|u|)
-        q = 2;
+        %
+        % Although q^(1/u0) could be subsumed under one variable,
+        % q and u0 have to be handled separately due to numerical issues.
+        q = 2;  % arbitrary choice
+        % ensures, that outer loudspeakers are at +-L/2
         u0 = nls/2.*log(q)./log(L/2+1);
-        
+
         x0(:,1) = X0(1) + sign(u).*(q.^abs(u./u0)-1);
         x0(:,7) = q.^abs(u/u0).*log(q)./u0.*du;  % dx = x0'(u)*du
-    end 
-    
+    end
 elseif strcmp('circle',geometry) || strcmp('circular',geometry)
     % === Circular array ===
     %

--- a/SFS_general/secondary_source_positions.m
+++ b/SFS_general/secondary_source_positions.m
@@ -105,16 +105,12 @@ if strcmp('line',geometry) || strcmp('linear',geometry)
     x0(:,3) = X0(3);
     x0(:,5) = -1;  % Direction of secondary sources points in -y direction
     
-    if isempty(conf.secondary_sources.grid) ...
-            || strcmp(conf.secondary_sources.grid, 'equally_spaced_points') ...
-            || ~isfield(conf.secondary_sources, 'logspread') ...
-            || isempty(conf.secondary_sources.logspread) ...
-            || conf.secondary_sources.logspread == 1.0
+    if conf.secondary_sources.logspread == 1.0
         % equi-distantant sampling
         x0(:,1) = X0(1) + linspace(-L/2,L/2,nls).';
         % Weight each secondary source by the inter-loudspeaker distance
         x0(:,7) = L./(nls-1);
-    elseif strcmp(conf.secondary_sources.grid, 'logarithmic')
+    else
         % the distance between the loudspeakers grows exponentially
         %
         %       L              exp(mu*|n|) + C
@@ -126,7 +122,7 @@ if strcmp('line',geometry) || strcmp('linear',geometry)
         %   C = -1
         % even number of loudspeakers:
         %   n = -N,...,-1,1,...,N and N = nls/2.
-        %   C = -0.5*(exp(mu)+1))
+        %   C = -0.5*(exp(mu)+1)
 
         N = floor(nls/2);
         mu = log(conf.secondary_sources.logspread)./(N-1);
@@ -140,9 +136,6 @@ if strcmp('line',geometry) || strcmp('linear',geometry)
         a0 = L/2/(exp(mu.*N)+C);
         x0(:,1) = sign(n).*(exp(mu.*abs(n))+C).*a0 + X0(1);
         x0(:,7) = exp(mu.*abs(n)).*a0.*mu;
-    else
-        error(['%s: the given linear grid ("%s") is not available'], ...
-             upper(mfilename), conf.secondary_sources.grid);
     end
 elseif strcmp('circle',geometry) || strcmp('circular',geometry)
     % === Circular array ===

--- a/validation/test_secondary_source_positions.m
+++ b/validation/test_secondary_source_positions.m
@@ -280,8 +280,10 @@ for ii=1:size(scenarios)
     case 1
         % Graphical mode
         figure
-        title('Equi-distant linear loudspeaker array');
         draw_loudspeakers(x0,[1 1 0],conf);
+        title(scenarios{ii,1});
+        xlabel('x / m')
+        ylabel('y / m')
     case 2
         % Numerical mode (verbose)
         if ~all(eq(size(x0),size(x0_ref)))
@@ -290,7 +292,7 @@ for ii=1:size(scenarios)
             error('%s: wrong value at %s.',upper(mfilename), scenarios{ii,1});
         end
     otherwise
-        
+
         error(['%s: modus has to be 0 (numerical quiet), 1 (graphical), ', ...
             'or 2 (numerical).'],upper(mfilename));
     end

--- a/validation/test_secondary_source_positions.m
+++ b/validation/test_secondary_source_positions.m
@@ -81,7 +81,7 @@ x0_linear_ref = [
     1.8000         0         0         0    -1.0000         0        0.2
     2.0000         0         0         0    -1.0000         0        0.2
     ];
-x0_linear_log_ref = [
+x0_linear_log_pos_ref = [
    -7.0000         0         0         0    -1.0000         0        8*log(2)
    -3.0000         0         0         0    -1.0000         0        4*log(2)
    -1.0000         0         0         0    -1.0000         0        2*log(2)
@@ -89,6 +89,15 @@ x0_linear_log_ref = [
     1.0000         0         0         0    -1.0000         0        2*log(2)
     3.0000         0         0         0    -1.0000         0        4*log(2)
     7.0000         0         0         0    -1.0000         0        8*log(2)
+    ];
+x0_linear_log_neg_ref = [
+   -7.0000         0         0         0    -1.0000         0        1*log(2)
+   -6.0000         0         0         0    -1.0000         0        2*log(2)
+   -4.0000         0         0         0    -1.0000         0        4*log(2)
+         0         0         0         0    -1.0000         0        8*log(2)
+    4.0000         0         0         0    -1.0000         0        4*log(2)
+    6.0000         0         0         0    -1.0000         0        2*log(2)
+    7.0000         0         0         0    -1.0000         0        1*log(2)
     ];
 x0_circle_ref = [
    2.00000   0.00000   0.00000  -1.00000   0.00000   0.00000   0.1995
@@ -244,10 +253,11 @@ x0_box_ref = [
 
 % test scenarios
 scenarios = {
-    'Equi-distant linear loudspeaker array'	'linear'	21   4.0 1.0 x0_linear_ref
-    'Logarithmic linear loudspeaker array'  'linear'	 7  14.0 4.0 x0_linear_log_ref
-    'Circular loudspeaker array'            'circle'    63   4.0 NaN x0_circle_ref
-    'Box shaped loudspeaker array'          'box'       84   4.0 NaN x0_box_ref
+    'Equi-distant linear loudspeaker array'	'linear'	21   4.0 1.0  x0_linear_ref
+    'Logarithmic linear loudspeaker array'  'linear'	 7  14.0 4.0  x0_linear_log_pos_ref
+    'Logarithmic linear loudspeaker array'  'linear'	 7  14.0 0.25 x0_linear_log_neg_ref
+    'Circular loudspeaker array'            'circle'    63   4.0 NaN  x0_circle_ref
+    'Box shaped loudspeaker array'          'box'       84   4.0 NaN  x0_box_ref
     };
 
 %% ===== Test secondary source positions =================================

--- a/validation/test_secondary_source_positions.m
+++ b/validation/test_secondary_source_positions.m
@@ -57,7 +57,6 @@ narginchk(nargmin,nargmax);
 
 %% ===== Main ============================================================
 conf = SFS_config;
-conf.secondary_sources.size = 4;
 % reference values
 x0_linear_ref = [
    -2.0000         0         0         0    -1.0000         0        0.2
@@ -81,6 +80,15 @@ x0_linear_ref = [
     1.6000         0         0         0    -1.0000         0        0.2
     1.8000         0         0         0    -1.0000         0        0.2
     2.0000         0         0         0    -1.0000         0        0.2
+    ];
+x0_linear_log_ref = [
+   -7.0000         0         0         0    -1.0000         0        8*log(2)
+   -3.0000         0         0         0    -1.0000         0        4*log(2)
+   -1.0000         0         0         0    -1.0000         0        2*log(2)
+         0         0         0         0    -1.0000         0        1*log(2)
+    1.0000         0         0         0    -1.0000         0        2*log(2)
+    3.0000         0         0         0    -1.0000         0        4*log(2)
+    7.0000         0         0         0    -1.0000         0        8*log(2)
     ];
 x0_circle_ref = [
    2.00000   0.00000   0.00000  -1.00000   0.00000   0.00000   0.1995
@@ -234,65 +242,48 @@ x0_box_ref = [
     2.0000   -2.2000         0         0    1.0000         0    0.2414
     ];
 
+% test scenarios
+scenarios = {
+    'Equi-distant linear loudspeaker array'	'linear'	21   4.0 1.0 x0_linear_ref
+    'Logarithmic linear loudspeaker array'  'linear'	 7  14.0 4.0 x0_linear_log_ref
+    'Circular loudspeaker array'            'circle'    63   4.0 NaN x0_circle_ref
+    'Box shaped loudspeaker array'          'box'       84   4.0 NaN x0_box_ref
+    };
 
 %% ===== Test secondary source positions =================================
-% Calculate current values
-% linear array
-conf.secondary_sources.geometry = 'linear';
-conf.secondary_sources.number = 21;
-x0_linear = secondary_source_positions(conf);
-% circular array
-conf.secondary_sources.geometry = 'circle';
-conf.secondary_sources.number = 63;
-x0_circle = secondary_source_positions(conf);
-% box form array
-conf.secondary_sources.geometry = 'box';
-conf.secondary_sources.number = 84;
-x0_box = secondary_source_positions(conf);
+% Start testing
+for ii=1:size(scenarios)
 
-if modus==0
-    % Numerical mode (quiet)
-    if ~all(eq(size(x0_linear),size(x0_linear_ref))) || ...
-            ~all(eq(size(x0_circle),size(x0_circle_ref))) || ...
-            ~all(eq(size(x0_box),size(x0_box_ref))) || ...
-            ~all(abs(x0_linear(:)-x0_linear_ref(:))<1e-4) || ...
-            ~all(abs(x0_circle(:)-x0_circle_ref(:))<1e-4) || ...
-            ~all(abs(x0_box(:)-x0_box_ref(:))<1e-4)
-        return;
+    conf.secondary_sources.geometry = scenarios{ii,2};
+    conf.secondary_sources.number = scenarios{ii,3};
+    conf.secondary_sources.size = scenarios{ii,4};
+    conf.secondary_sources.logspread = scenarios{ii,5};
+    x0_ref = scenarios{ii,6};
+
+    x0 = secondary_source_positions(conf);
+    switch modus
+    case 0
+        % Numerical mode (quiet)
+        if ~all(eq(size(x0),size(x0_ref))) || ~all(abs(x0(:)-x0_ref(:))<1e-4)
+            return;
+        end
+    case 1
+        % Graphical mode
+        figure
+        title('Equi-distant linear loudspeaker array');
+        draw_loudspeakers(x0,[1 1 0],conf);
+    case 2
+        % Numerical mode (verbose)
+        if ~all(eq(size(x0),size(x0_ref)))
+            error('%s: wrong size of %s.',upper(mfilename), scenarios{ii,1});
+        elseif ~all(abs(x0(:)-x0_ref(:))<1e-4)
+            error('%s: wrong value at %s.',upper(mfilename), scenarios{ii,1});
+        end
+    otherwise
+        
+        error(['%s: modus has to be 0 (numerical quiet), 1 (graphical), ', ...
+            'or 2 (numerical).'],upper(mfilename));
     end
-elseif modus==2
-    if ~all(eq(size(x0_linear),size(x0_linear_ref)))
-        error('%s: wrong size of linear array.',upper(mfilename));
-    elseif ~all(abs(x0_linear(:)-x0_linear_ref(:))<1e-4)
-        error('%s: wrong value at linear array.',upper(mfilename));
-    end
-    if ~all(eq(size(x0_circle),size(x0_circle_ref)))
-        error('%s: wrong size of circular array.',upper(mfilename));
-    elseif ~all(abs(x0_circle(:)-x0_circle_ref(:))<1e-4)
-        error('%s: wrong value at circular array.',upper(mfilename));
-    end
-    if ~all(eq(size(x0_box),size(x0_box_ref))) 
-        error('%s: wrong size of box shaped array.',upper(mfilename));
-    elseif ~all(abs(x0_box(:)-x0_box_ref(:))<1e-4)
-        error('%s: wrong value at box shaped array.',upper(mfilename));
-    end
-elseif modus==1
-    % Graphical mode
-    close all;
-    % draw results
-    figure
-    title('Linear loudspeaker array');
-    draw_loudspeakers(x0_linear,[1 1 0],conf);
-    figure
-    title('Circular loudspeaker array');
-    draw_loudspeakers(x0_circle,[1 1 0],conf);
-    figure
-    title('Box shape loudspeaker array');
-    draw_loudspeakers(x0_box,[1 1 0],conf);
-else
-    error(['%s: modus has to be 0 (numerical quiet), 1 (numerical), ', ...
-            'or 2 (graphical).'],upper(mfilename));
 end
-
 
 status = true;


### PR DESCRIPTION
Try:

```MATLAB
close all
clear variables
SFS_start;
conf = SFS_config;

conf.secondary_sources.geometry = 'linear';
conf.secondary_sources.grid = 'logarithmic';
conf.secondary_sources.logspread = 5;

idx = 0;
fdx = 1;
markers = {'diamond', 'square'};
for N0 = [20, 21]
  conf.secondary_sources.number = N0;
  y0 = zeros(N0,1); 
  for spread = [0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 5.0]
     conf.secondary_sources.logspread = spread;
     
     x0 = secondary_source_positions(conf);
     y0(:) = idx;
     figure(1);
     hold on;
     plot(x0(:,1),y0,markers{fdx});
     hold off;
     figure(2);
     hold on;
     plot(x0(2:end-1,1), ...
         (x0(1:end-2,1)-x0(2:end-1,1))./(x0(2:end-1,1)-x0(3:end,1)),[markers{fdx} '-']);
     hold off;
     
     cdx = floor(N0/2)+1;
     fprintf('spread: %2.2f\n', ...
         (x0(end,1)-x0(end-1,1))./(x0(cdx,1)-x0(cdx-1,1)) );
     idx = idx + 0.1;
  end
  fdx = fdx + 1;
end
hold off;
figure(1), title('loudspeaker positions');
figure(2), title('ratio of adjacent loudspeaker spacings');
```

I am still not sure, how to handle the new functionality in the ``conf`` struct: In principle, both logarithmic and equi-distant sampling could be handled using ``conf.secondary_source.logspread``, since ``1.0`` would results in an equi-distant spacing. Should we nevertheless use ``conf.secondary_sources.grid`` in addition?