### PR TITLE
Extend spectrum_from_signal and signal_from_spectrum to multichannel signals

### DIFF
--- a/SFS_general/signal_from_spectrum.m
+++ b/SFS_general/signal_from_spectrum.m
@@ -110,6 +110,7 @@ compspec = amplitude .* exp(1i*phase);
 % Build the inverse fft and assume spectrum is conjugate symmetric
 outsig = real(ifft(compspec));
 
+
 %% ===== Output ==========================================================
 % undo reshape and permute
 outsig = reshape(outsig, [samples, s(2:end)]);

--- a/SFS_general/signal_from_spectrum.m
+++ b/SFS_general/signal_from_spectrum.m
@@ -1,13 +1,13 @@
 function outsig = signal_from_spectrum(amplitude,phase,f,dim,conf)
 %SIGNAL_FROM_SPECTRUM time signal from single-sided spectrum
 %
-%   Usage: outsig = signal_from_spectrum(amplitude,phase,f,conf)
+%   Usage: outsig = signal_from_spectrum(amplitude,phase,f,[dim],conf)
 %
 %   Input parameters:
 %       amplitude   - the single-sided amplitude spectrum
 %       phase       - the single-sided phase spectrum / rad
 %       f           - the corresponding frequency vector
-%       dim         - dimension along which the fft is performed
+%       dim         - dimension along which the ifft is performed
 %       conf        - configuration struct (see SFS_config)
 %
 %   Output parameters:
@@ -77,6 +77,10 @@ fs = conf.fs;
 %% ===== Regenerating wave form from spectrum ============================
 % Provided number of frequency bins
 bins = length(f);
+if bins ~= Nx
+   error('%s: size of spectrum does not match length of frequency vector',...
+       upper(mfilename));
+end
 
 if f(end) == fs/2  % -> even time signal length
     % Length of the signal to generate

--- a/SFS_general/spectrum_from_signal.m
+++ b/SFS_general/spectrum_from_signal.m
@@ -80,7 +80,7 @@ useplot = conf.plot.useplot;
 compspec = fft(signal,[],1);
 
 % Length of the signal => number of points of fft
-bins = length(signal);
+bins = size(signal,1);
 
 if mod(bins,2)  % For odd signal length
     % Calculate corresponding frequency axis

--- a/SFS_general/spectrum_from_signal.m
+++ b/SFS_general/spectrum_from_signal.m
@@ -4,7 +4,7 @@ function varargout = spectrum_from_signal(signal,dim,conf)
 %   Usage: [amplitude,phase,f] = spectrum_from_signal(sig,[dim],conf)
 %
 %   Input parameters:
-%       signal      - one channel audio (time) signal
+%       signal      - multi channel audio (time) signal
 %       dim         - dimension along which the fft is performed
 %       conf        - configuration struct (see SFS_config)
 %
@@ -105,6 +105,7 @@ else  % For even signal length
     amplitude = [amplitude(1,:); 2*amplitude(2:end-1,:); amplitude(end,:)] / bins;
 end
 
+
 %% ===== Plotting ========================================================
 if nargout==0 || useplot
     figure; title('Spectrum');
@@ -115,6 +116,7 @@ if nargout==0 || useplot
     semilogx(f,unwrap(phase,[],1)); xlim([1, fs/2]);
     grid on; xlabel('frequency / Hz'); ylabel('phase / rad')
 end
+
 
 %% ===== Output ==========================================================
 % Return values


### PR DESCRIPTION
Try:
```MATLAB
SFS_start;
conf = SFS_config;
conf.plot.useplot = true;
SOFAstart;

irs = get_ir(dummy_irs(1024,conf),[0,0,0],0,[1 0 0], 'cartesian',conf);
[b1,a1] = butter(5,0.1);
[b2,a2] = butter(10,0.2);

sig1 = filter(b1,a1,irs(:,1));
sig2 = filter(b2,a2,irs(:,1));
sig = [irs(:,1), sig1, sig2];

[amp, phase, f] = spectrum_from_signal(sig,1,conf);
sig_inv = signal_from_spectrum(amp, phase, f, 1,conf);
figure, 
plot(sig,'k');
hold on
plot(sig_inv, '--');
hold off;

[amp, phase, f] = spectrum_from_signal(sig,conf);
sig_inv = signal_from_spectrum(amp, phase, f, conf);
figure, 
plot(sig,'k');
hold on
plot(sig_inv, '--');
hold off;

[amp, phase, f] = spectrum_from_signal(sig.',2,conf);
sig_inv = signal_from_spectrum(amp, phase,f,2,conf);
figure, 
plot(sig,'k');
hold on
plot(sig_inv.', '--');
hold off;
```